### PR TITLE
feat(theme): add dark mode with system / light / dark toggle

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -1,5 +1,6 @@
 ---
 import Sidebar from './Sidebar.astro';
+import ThemeToggle from './ThemeToggle.astro';
 
 const links = [
   { href: '/', label: 'Home' },
@@ -24,26 +25,29 @@ const activeHref = links
     >
       Mapping Systems
     </a>
-    <ul class="flex gap-7 text-sm">
-      {links.map(({ href, label }) => {
-        const isActive = href === activeHref;
-        return (
-          <li>
-            <a
-              href={href}
-              class:list={[
-                'no-underline transition-colors',
-                isActive
-                  ? 'text-accent font-medium'
-                  : 'text-muted hover:text-text',
-              ]}
-            >
-              {label}
-            </a>
-          </li>
-        );
-      })}
-    </ul>
+    <div class="flex items-center gap-6">
+      <ul class="flex gap-7 text-sm">
+        {links.map(({ href, label }) => {
+          const isActive = href === activeHref;
+          return (
+            <li>
+              <a
+                href={href}
+                class:list={[
+                  'no-underline transition-colors',
+                  isActive
+                    ? 'text-accent font-medium'
+                    : 'text-muted hover:text-text',
+                ]}
+              >
+                {label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+      <ThemeToggle />
+    </div>
   </nav>
 
   {/* Mobile nav: <details> gives us collapsible behavior with no JS, and
@@ -122,6 +126,10 @@ const activeHref = links
         </ul>
         <div class="border-t border-border pt-5">
           <Sidebar />
+        </div>
+        <div class="border-t border-border pt-5 flex items-center gap-3">
+          <ThemeToggle />
+          <span class="text-sm text-muted">Theme</span>
         </div>
       </div>
     </div>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -16,7 +16,7 @@ const activeHref = links
   .filter((l) => (l.href === '/' ? path === '/' : path === l.href || path.startsWith(l.href + '/')))
   .sort((a, b) => b.href.length - a.href.length)[0]?.href;
 ---
-<header class="sticky top-0 z-50 border-b border-border bg-bg/85 backdrop-blur">
+<header class="sticky top-0 z-50 border-b border-border bg-bg">
   {/* Desktop nav */}
   <nav class="hidden lg:flex max-w-7xl mx-auto px-4 sm:px-6 py-4 items-center justify-between">
     <a
@@ -61,43 +61,50 @@ const activeHref = links
       >
         Mapping Systems
       </a>
-      <span class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-text">
-        {/* Hamburger icon, rotates/morphs into X when details is open */}
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="hidden group-open:block"
-          aria-hidden="true"
-        >
-          <line x1="18" y1="6" x2="6" y2="18" />
-          <line x1="6" y1="6" x2="18" y2="18" />
-        </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="block group-open:hidden"
-          aria-hidden="true"
-        >
-          <line x1="4" y1="6" x2="20" y2="6" />
-          <line x1="4" y1="12" x2="20" y2="12" />
-          <line x1="4" y1="18" x2="20" y2="18" />
-        </svg>
-        <span class="sr-only">Toggle menu</span>
-      </span>
+      <div class="flex items-center gap-2">
+        {/* Theme toggle, always visible. stopPropagation prevents clicks
+            from also toggling the <details> open/closed. */}
+        <span onclick="event.stopPropagation()">
+          <ThemeToggle />
+        </span>
+        <span class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-text">
+          {/* Hamburger icon, morphs into X when details is open */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="hidden group-open:block"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="block group-open:hidden"
+            aria-hidden="true"
+          >
+            <line x1="4" y1="6" x2="20" y2="6" />
+            <line x1="4" y1="12" x2="20" y2="12" />
+            <line x1="4" y1="18" x2="20" y2="18" />
+          </svg>
+          <span class="sr-only">Toggle menu</span>
+        </span>
+      </div>
     </summary>
 
     {/* Drawer: top-level links + the full course sidebar so students can
@@ -126,10 +133,6 @@ const activeHref = links
         </ul>
         <div class="border-t border-border pt-5">
           <Sidebar />
-        </div>
-        <div class="border-t border-border pt-5 flex items-center gap-3">
-          <ThemeToggle />
-          <span class="text-sm text-muted">Theme</span>
         </div>
       </div>
     </div>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,156 @@
+---
+/*
+  Three-state theme toggle: system → light → dark → system.
+
+  - "system" follows the OS preference and updates live when the OS changes.
+  - "light" / "dark" persist in localStorage and override the OS preference.
+
+  The current state is reflected in the data-theme-pref attribute on <html>
+  (set by the anti-FOUC inline script in BaseLayout.astro). CSS shows the
+  matching icon based on that attribute, so there's no JS-driven icon swap
+  flash.
+
+  Designed to survive Astro's ClientRouter view transitions: the click
+  listener is (re)attached on every astro:page-load; the system-preference
+  watcher is registered once at module load and persists.
+*/
+
+interface Props {
+  class?: string;
+}
+
+const { class: className = '' } = Astro.props;
+---
+<button
+  type="button"
+  data-theme-toggle
+  aria-label="Toggle theme (system / light / dark)"
+  title="Toggle theme"
+  class:list={[
+    'inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-text hover:bg-surface transition-colors',
+    className,
+  ]}
+>
+  <svg
+    data-theme-icon="system"
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="2" y="3" width="20" height="14" rx="2" />
+    <line x1="8" y1="21" x2="16" y2="21" />
+    <line x1="12" y1="17" x2="12" y2="21" />
+  </svg>
+  <svg
+    data-theme-icon="light"
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+  </svg>
+  <svg
+    data-theme-icon="dark"
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+</button>
+
+<script>
+  type Pref = 'system' | 'light' | 'dark';
+  const ORDER: Pref[] = ['system', 'light', 'dark'];
+
+  function readPref(): Pref {
+    try {
+      const v = localStorage.getItem('theme');
+      return v === 'light' || v === 'dark' ? v : 'system';
+    } catch {
+      return 'system';
+    }
+  }
+
+  function writePref(pref: Pref): void {
+    try {
+      if (pref === 'system') localStorage.removeItem('theme');
+      else localStorage.setItem('theme', pref);
+    } catch {
+      /* localStorage unavailable; toggle still works for the session via the
+         data-theme-pref attribute and class swap. */
+    }
+  }
+
+  function applyDarkClass(): void {
+    const pref = readPref();
+    const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const isDark = pref === 'dark' || (pref === 'system' && systemDark);
+    document.documentElement.classList.toggle('dark', isDark);
+    document.documentElement.setAttribute('data-theme-pref', pref);
+  }
+
+  function cycleTheme(): void {
+    const current = readPref();
+    const next = ORDER[(ORDER.indexOf(current) + 1) % ORDER.length];
+    writePref(next);
+    applyDarkClass();
+  }
+
+  function attachToggleListeners(): void {
+    document.querySelectorAll<HTMLButtonElement>('[data-theme-toggle]').forEach((btn) => {
+      // Replace listener defensively in case this runs more than once on a page.
+      btn.replaceWith(btn.cloneNode(true));
+    });
+    document.querySelectorAll<HTMLButtonElement>('[data-theme-toggle]').forEach((btn) => {
+      btn.addEventListener('click', cycleTheme);
+    });
+  }
+
+  // (Re)attach on every navigation under ClientRouter. Also fires on initial load.
+  document.addEventListener('astro:page-load', attachToggleListeners);
+
+  // Live system-preference watcher: only act when user is in 'system' mode.
+  // Registered once at module load; persists across view transitions.
+  const mq = window.matchMedia('(prefers-color-scheme: dark)');
+  const onSystemChange = () => {
+    if (readPref() === 'system') applyDarkClass();
+  };
+  if (mq.addEventListener) mq.addEventListener('change', onSystemChange);
+  else mq.addListener?.(onSystemChange); // Safari < 14
+</script>
+
+<style>
+  /* Show only the icon matching the current theme preference. The
+     data-theme-pref attribute is set on <html> by the anti-FOUC bootstrap. */
+  [data-theme-icon] {
+    display: none;
+  }
+  html[data-theme-pref='system'] [data-theme-icon='system'],
+  html[data-theme-pref='light'] [data-theme-icon='light'],
+  html[data-theme-pref='dark'] [data-theme-icon='dark'] {
+    display: block;
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,7 +40,14 @@ const {
         localStorage.theme === 'dark'   → forced dark
         localStorage.theme === null     → 'system' mode (follow OS preference)
     */}
-    <script is:inline>
+    {/*
+      data-astro-rerun makes ClientRouter re-execute this script after every
+      view transition. Without it, the script only runs on initial page load;
+      ClientRouter resets <html> attributes on each swap, so .dark and
+      data-theme-pref would be wiped (page flips to light, toggle icons
+      disappear) on the second navigation.
+    */}
+    <script is:inline data-astro-rerun>
       (function () {
         var pref;
         try { pref = localStorage.getItem('theme'); } catch (_) { pref = null; }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -30,6 +30,30 @@ const {
     />
     <title>{title} | Mapping Systems</title>
     <ClientRouter />
+    {/*
+      Anti-FOUC theme bootstrap. Runs synchronously before paint so the .dark
+      class is on <html> before any CSS applies, preventing a flash of light
+      theme on first load when the user prefers dark.
+
+      State model:
+        localStorage.theme === 'light'  → forced light
+        localStorage.theme === 'dark'   → forced dark
+        localStorage.theme === null     → 'system' mode (follow OS preference)
+    */}
+    <script is:inline>
+      (function () {
+        var pref;
+        try { pref = localStorage.getItem('theme'); } catch (_) { pref = null; }
+        var systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var isDark = pref === 'dark' || (pref !== 'light' && systemDark);
+        document.documentElement.classList.toggle('dark', isDark);
+        // data-theme-pref drives which toggle icon (sun/moon/monitor) shows via CSS.
+        document.documentElement.setAttribute(
+          'data-theme-pref',
+          pref === 'light' || pref === 'dark' ? pref : 'system'
+        );
+      })();
+    </script>
   </head>
   <body class="min-h-screen bg-bg text-text antialiased">
     <Navigation />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const assignments = lessons
     <div class="mt-8 flex gap-3">
       <a
         href="/lessons"
-        class="inline-flex items-center px-4 py-2 rounded-lg bg-text text-white text-sm font-medium no-underline hover:bg-accent hover:text-white transition-colors"
+        class="inline-flex items-center px-4 py-2 rounded-lg bg-text text-bg text-sm font-medium no-underline hover:bg-accent hover:text-bg transition-colors"
       >
         Browse lessons →
       </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,10 +1,17 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-/* ---------- Theme tokens ----------
+/* Class-based dark mode: html.dark (or any descendant) toggles the dark
+   variant. We set this via a small inline script in BaseLayout that runs
+   before paint, so there's no flash of light theme before the swap. */
+@variant dark (&:where(.dark, .dark *));
+
+/* ---------- Theme tokens (light) ----------
    Palette inspired by designpractices.org: warm off-white background,
-   serif display type, vivid red-orange links, purple accent.
-   Tokens use HSL channels so dark mode is a single variable swap later. */
+   vivid red-orange links, purple accent. The `:root`/`html.dark` blocks
+   below override these tokens; @theme registers them so Tailwind generates
+   utility classes (bg-bg, text-accent, etc.) that read whichever variable
+   value is in scope. */
 
 @theme {
   --color-bg: hsl(0 0% 98%);
@@ -22,6 +29,30 @@
   --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
+
+/* ---------- Theme tokens (dark) ----------
+   Mirrors designpractices.org's dark theme: warm dark slate background
+   instead of pure gray, a mustard accent in place of the light-mode purple,
+   and a softer red link color that meets contrast against dark surfaces. */
+
+html.dark {
+  --color-bg: hsl(210 6% 12%);
+  --color-surface: hsl(210 6% 16%);
+  --color-surface-strong: hsl(210 6% 22%);
+  --color-text: hsl(0 0% 93%);
+  --color-muted: hsl(0 0% 70%);
+  --color-subtle: hsl(0 0% 55%);
+  --color-border: hsl(210 6% 26%);
+  --color-accent: hsl(42 76% 58%);
+  --color-accent-soft: hsl(42 35% 18%);
+  --color-link: hsl(10 70% 68%);
+  --color-link-hover: hsl(10 70% 78%);
+}
+
+/* Tell the browser which scheme we're in so native UI (scrollbars, form
+   controls) renders to match. */
+:root { color-scheme: light; }
+html.dark { color-scheme: dark; }
 
 /* ---------- Base ---------- */
 
@@ -201,4 +232,39 @@ pre.astro-code code {
 .output-svg svg {
   max-width: 100%;
   height: auto;
+}
+
+/* ---------- Dark-mode tweaks for code & output blocks ----------
+   Shiki's dual-theme config emits --shiki-dark and --shiki-dark-bg on every
+   code span; these rules swap to those values when html.dark is set. */
+
+html.dark .astro-code,
+html.dark .astro-code span {
+  color: var(--shiki-dark) !important;
+}
+
+html.dark pre.astro-code,
+html.dark .prose pre.astro-code {
+  background-color: var(--shiki-dark-bg) !important;
+}
+
+/* Notebook output: red error block needs its own dark variant since the
+   light error palette (#fef2f2 on #991b1b) reads as glaring on a dark page. */
+html.dark .output-error pre {
+  background-color: hsl(0 30% 14%);
+  color: hsl(0 80% 80%);
+  border-color: hsl(0 35% 28%);
+}
+
+/* Notebook DataFrame tables: slightly lift the surface so rows separate
+   cleanly from the page bg in dark mode. */
+html.dark .output-html th {
+  background-color: hsl(210 6% 20%);
+}
+
+/* Image figures: subtle border instead of shadow in dark mode (shadows
+   disappear on dark backgrounds). */
+html.dark .output-figure img {
+  box-shadow: none;
+  border: 1px solid var(--color-border);
 }


### PR DESCRIPTION
## Summary

Adds dark mode with a 3-state toggle (system → light → dark) in the nav header.

- **System** follows the OS preference and updates live when the OS toggles (macOS auto-dark, etc.).
- **Light** / **Dark** persist via `localStorage` and override the OS.
- No flash of wrong theme: an inline `<script>` in `<head>` sets `.dark` + `data-theme-pref` synchronously before paint.
- Survives Astro's `ClientRouter` view transitions: click listener re-attaches on `astro:page-load`; system-pref watcher registered once at module load.

## Color direction

Light theme palette is unchanged. Dark theme mirrors designpractices.org's dark tokens:

| Token | Light | Dark |
|---|---|---|
| `--color-bg` | warm off-white `hsl(0 0% 98%)` | warm dark slate `hsl(210 6% 12%)` |
| `--color-text` | near-black `hsl(203 11% 15%)` | off-white `hsl(0 0% 93%)` |
| `--color-accent` | purple `hsl(275 50% 53%)` | mustard `hsl(42 76% 58%)` |
| `--color-link` | red-orange `hsl(10 85% 50%)` | softer red `hsl(10 70% 68%)` |

Mustard reads warmer at night and gives dark mode its own visual identity (vs forcing the light-mode purple to work on a dark surface).

## Implementation notes

- **Tailwind 4 dark variant** — added `@variant dark (&:where(.dark, .dark *))` so `dark:` utilities work, but most of the UI doesn't use them: every theme color is a CSS custom property, so `bg-bg`, `text-accent`, etc. automatically pick up the swapped values when `html.dark` is set. The `dark:` variant is reserved for cases where light/dark need genuinely different classes.
- **Shiki** — was already configured for dual themes (`github-light` + `github-dark`), so every code span carries `--shiki-dark` and `--shiki-dark-bg`. A small CSS rule under `html.dark` swaps to those vars; no Shiki reconfig needed.
- **Notebook outputs** — error blocks, table headers, and image figures get dark-tuned variants where the light defaults (red-on-pink, white th bg, drop shadow) read poorly on a dark page.
- **Homepage CTA fix** — the "Browse lessons" button was `bg-text text-white` which became invisible in dark mode (light bg + white text). Changed `text-white` → `text-bg` so the button text always inverts correctly: light mode shows dark bg + light text; dark mode shows light bg + dark text.
- **Toggle UX** — three SVG icons (monitor / sun / moon), one shown at a time via CSS reading `html[data-theme-pref="..."]`. No JS-driven icon swap flash.

## Test plan

- [ ] Visit homepage at default (system mode); verify the toggle icon matches your OS theme
- [ ] Click toggle — verify cycle: system → light (sun icon, page goes light) → dark (moon icon, page goes dark) → system
- [ ] In `system` mode, change OS appearance — verify the page swaps live
- [ ] Refresh the page in any mode — verify no flash of wrong theme
- [ ] Navigate between lessons — verify theme persists, toggle keeps working
- [ ] Open the mobile menu (resize to <`lg`) — verify toggle is at the bottom of the drawer and works there too
- [ ] Spot-check pages: a notebook lesson with code blocks (e.g. `/lessons/tutorials/geoprocessing`), the syllabus (long DOI links), homepage hero, lessons index — all should read cleanly in both modes

## Screenshots

Local screenshots live at `/tmp/dark-mode-pr/{01-home-light,02-home-dark,03-lesson-dark}.png` — drag them into this PR description in the GitHub UI to attach them inline (uploads to user-images.githubusercontent.com).
