### PR TITLE
feat(bibliography): group by Zotero sub-collections + searchable filter

### DIFF
--- a/scripts/fetch-zotero.ts
+++ b/scripts/fetch-zotero.ts
@@ -32,11 +32,28 @@ interface ZoteroAPIItem {
     itemType?: string;
     title?: string;
     tags?: { tag: string; type?: number }[];
+    /** Keys of every collection this item belongs to (parent + sub). */
+    collections?: string[];
     [k: string]: unknown;
   };
   csljson?: Record<string, unknown>;
   bib?: string; // pre-rendered HTML
   bibtex?: string;
+}
+
+interface ZoteroAPICollection {
+  key: string;
+  data: {
+    name: string;
+    parentCollection?: string | false;
+  };
+}
+
+interface SubCollection {
+  key: string;
+  name: string;
+  /** Position from Zotero's manual ordering, if available — used as a sort key. */
+  position?: number;
 }
 
 interface BibliographyEntry {
@@ -47,8 +64,11 @@ interface BibliographyEntry {
   doi?: string;
   date?: string;
   year?: number;
-  /** Tags from Zotero (lowercased + sorted for stable ordering). */
+  /** Tags from Zotero (deduped + trimmed + sorted). */
   tags: string[];
+  /** Keys of sub-collections this item is in. Excludes the parent collection
+      itself so we can render "uncategorized" sections cleanly. */
+  subcollections: string[];
   csl: unknown;
   /** Pre-rendered HTML citation in the configured style. */
   bib: string;
@@ -61,6 +81,10 @@ interface BibliographyOutput {
   fetchedAt: string;
   collectionId: string;
   count: number;
+  /** Direct child collections of the configured root collection. The
+      bibliography page renders one section per sub-collection, plus an
+      "Uncategorized" section for items in the root only. */
+  subcollections: SubCollection[];
   entries: BibliographyEntry[];
 }
 
@@ -115,7 +139,28 @@ async function fetchAllItems(): Promise<ZoteroAPIItem[]> {
   return all;
 }
 
-function normalize(item: ZoteroAPIItem): BibliographyEntry | null {
+async function fetchSubcollections(): Promise<SubCollection[]> {
+  const apiKey = process.env.ZOTERO_KEY;
+  const { userId, libraryType, collectionId } = ZOTERO;
+  const url = `https://api.zotero.org/${libraryType}/${userId}/collections/${collectionId}/collections?limit=100`;
+  const headers: Record<string, string> = { 'Zotero-API-Version': '3' };
+  if (apiKey) headers['Zotero-API-Key'] = apiKey;
+
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(`Zotero API error fetching sub-collections: ${res.status} ${res.statusText}`);
+  }
+  const collections: ZoteroAPICollection[] = await res.json();
+  // Direct children only — Zotero's collections endpoint returns the full
+  // descendant tree, but we keep one level (parent matches our root) since
+  // the user's mental model is one level of grouping.
+  return collections
+    .filter((c) => c.data.parentCollection === collectionId)
+    .map((c) => ({ key: c.key, name: c.data.name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function normalize(item: ZoteroAPIItem, subcollectionKeys: Set<string>): BibliographyEntry | null {
   // When the API request asks for `include=csljson,bib,bibtex`, the response
   // omits the standard `data` field — every metadata read here goes through
   // csljson, which uses CSL JSON capitalization (URL, DOI).
@@ -136,9 +181,15 @@ function normalize(item: ZoteroAPIItem): BibliographyEntry | null {
   const year = issued?.['date-parts']?.[0]?.[0];
 
   // Pull tags from Zotero `data.tags` (where users actually edit them in
-  // the Zotero app). Lowercase + dedupe + sort for a stable rendering.
+  // the Zotero app). Trim + dedupe + sort for a stable rendering.
   const rawTags = item.data?.tags?.map((t) => t.tag).filter((s): s is string => typeof s === 'string') ?? [];
   const tags = Array.from(new Set(rawTags.map((t) => t.trim()).filter(Boolean))).sort();
+
+  // Filter the item's collections to just the sub-collections we know about.
+  // (`data.collections` includes the parent collection itself + any others
+  // outside our scope; we want only the direct children of our root.)
+  const itemCollections = item.data?.collections ?? [];
+  const subcollections = itemCollections.filter((k) => subcollectionKeys.has(k)).sort();
 
   return {
     key: item.key,
@@ -149,6 +200,7 @@ function normalize(item: ZoteroAPIItem): BibliographyEntry | null {
     date: year ? String(year) : undefined,
     year: typeof year === 'number' ? year : undefined,
     tags,
+    subcollections,
     csl,
     bib: item.bib ?? '',
     bibtex: item.bibtex ?? '',
@@ -166,15 +218,17 @@ async function main() {
   console.log(`  ${ZOTERO.libraryType}/${ZOTERO.userId} · collection ${ZOTERO.collectionId} · style ${ZOTERO.style}`);
 
   let items: ZoteroAPIItem[];
+  let subcollections: SubCollection[];
   try {
-    items = await fetchAllItems();
+    [items, subcollections] = await Promise.all([fetchAllItems(), fetchSubcollections()]);
   } catch (err) {
     console.error(`  ✗ ${err instanceof Error ? err.message : err}`);
     process.exit(1);
   }
 
+  const subcollectionKeys = new Set(subcollections.map((s) => s.key));
   const entries = items
-    .map(normalize)
+    .map((it) => normalize(it, subcollectionKeys))
     .filter((e): e is BibliographyEntry => e !== null);
 
   const output: BibliographyOutput = {
@@ -182,12 +236,15 @@ async function main() {
     fetchedAt: new Date().toISOString(),
     collectionId: ZOTERO.collectionId,
     count: entries.length,
+    subcollections,
     entries,
   };
 
   mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
   writeFileSync(OUTPUT_PATH, JSON.stringify(output, null, 2), 'utf-8');
-  console.log(`  ✓ ${OUTPUT_PATH} (${entries.length} entries, fetched ${items.length})`);
+  console.log(
+    `  ✓ ${OUTPUT_PATH} (${entries.length} entries, ${subcollections.length} sub-collections, fetched ${items.length})`,
+  );
 }
 
 main();

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -59,6 +59,9 @@ const bibliography = defineCollection({
     date: z.string().optional(),
     year: z.number().optional(),
     tags: z.array(z.string()).default([]),
+    /** Keys of Zotero sub-collections this entry belongs to (top-level
+        groupings on the bibliography page). */
+    subcollections: z.array(z.string()).default([]),
     csl: z.unknown(),
     bib: z.string(),
     bibtex: z.string(),

--- a/src/content/resources/maps-yszif0goa1g.md
+++ b/src/content/resources/maps-yszif0goa1g.md
@@ -4,7 +4,7 @@ slug: "maps-yszif0goa1g"
 source: arena
 arenaId: 3438044
 blockCount: 63
-lastFetched: "2026-05-15T23:18:14.315Z"
+lastFetched: "2026-05-16T13:37:28.223Z"
 description: "Course-related cartographic references and inspiration."
 tags:
   - "cartography"

--- a/src/data/arena/maps-yszif0goa1g.json
+++ b/src/data/arena/maps-yszif0goa1g.json
@@ -9,7 +9,7 @@
     "cartography",
     "inspiration"
   ],
-  "fetchedAt": "2026-05-15T23:18:14.317Z",
+  "fetchedAt": "2026-05-16T13:37:28.225Z",
   "blocks": [
     {
       "id": 33361790,

--- a/src/data/zotero.json
+++ b/src/data/zotero.json
@@ -1,8 +1,38 @@
 {
   "style": "chicago-author-date",
-  "fetchedAt": "2026-05-15T23:18:39.358Z",
+  "fetchedAt": "2026-05-16T00:36:10.451Z",
   "collectionId": "847AR7X4",
   "count": 163,
+  "subcollections": [
+    {
+      "key": "UP4V2S7X",
+      "name": "AI"
+    },
+    {
+      "key": "PGTZV2GX",
+      "name": "cartography + visualization"
+    },
+    {
+      "key": "T3AL7PGA",
+      "name": "case studies"
+    },
+    {
+      "key": "AGAC9I88",
+      "name": "infrastructure"
+    },
+    {
+      "key": "ERJ92FM8",
+      "name": "methods"
+    },
+    {
+      "key": "6SPRPNXF",
+      "name": "networks"
+    },
+    {
+      "key": "DRE4ZF6F",
+      "name": "theory"
+    }
+  ],
   "entries": [
     {
       "key": "LXJCF8AB",
@@ -12,6 +42,7 @@
       "date": "1937",
       "year": 1937,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/LXJCF8AB",
         "type": "map",
@@ -52,6 +83,7 @@
         "ingegrating human and natural sciences",
         "landscape/regional and urban planning"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/FKRNLQ5R",
         "type": "book",
@@ -109,6 +141,7 @@
         "Perception",
         "Visual landscape"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/AGI4ULN8",
         "type": "chapter",
@@ -170,6 +203,7 @@
       "date": "2016",
       "year": 2016,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/URKJDZ84",
         "type": "chapter",
@@ -204,6 +238,7 @@
         "Computer networks",
         "Information networks"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/XZ4EGKPF",
         "type": "book",
@@ -244,6 +279,7 @@
       "date": "2011",
       "year": 2011,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/7IIFNURW",
         "type": "book",
@@ -291,6 +327,7 @@
       "date": "2019",
       "year": 2019,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/JW4XBVGH",
         "type": "article-journal",
@@ -348,6 +385,7 @@
         "Economics",
         "Policy"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/TFS35BIB",
         "type": "article-journal",
@@ -402,6 +440,7 @@
       "date": "2012",
       "year": 2012,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/6ZU3JYPM",
         "type": "article-journal",
@@ -440,6 +479,7 @@
       "date": "1999",
       "year": 1999,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/4CQGLS4X",
         "type": "chapter",
@@ -477,6 +517,7 @@
       "date": "2025",
       "year": 2025,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/VG5HM3A5",
         "type": "book",
@@ -518,6 +559,7 @@
       "date": "2023",
       "year": 2023,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/6NNGGHNH",
         "type": "webpage",
@@ -558,6 +600,7 @@
       "title": "I learned about something called a “relative elevation model” derived from #lidar point cloud data and now I’m obsessed with figuring out how to make one with my dataset. #arcgis https://t.co/bMpiNBGAYv",
       "url": "https://x.com/mrbrianolson/status/1052384614528872449/photo/1",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/S7E24NFH",
         "type": "post",
@@ -593,6 +636,7 @@
       "date": "2018",
       "year": 2018,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/RWK3CBNQ",
         "type": "webpage",
@@ -637,6 +681,7 @@
       "title": "Field Notes No. 1: The Detroit Geographical Expedition",
       "date": "1969",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/QHXQJALL",
         "type": "report",
@@ -667,6 +712,7 @@
       "date": "1972",
       "year": 1972,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/7MAJ2AI4",
         "type": "report",
@@ -701,6 +747,7 @@
       "date": "1971",
       "year": 1971,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/J3CARVV2",
         "type": "report",
@@ -739,6 +786,7 @@
       "date": "1970",
       "year": 1970,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/ZR82EC99",
         "type": "report",
@@ -776,6 +824,7 @@
       "title": "Mercator Projection of the World",
       "url": "http://alabamamaps.ua.edu/contemporarymaps/world/world/world2.jpg",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/8RY9ASZ4",
         "type": "map",
@@ -802,6 +851,7 @@
       "tags": [
         "network analysis"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/4KCC7TCE",
         "type": "chapter",
@@ -841,6 +891,7 @@
         "Environmental social sciences",
         "Mathematics and computing"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/9KGZ5VSV",
         "type": "article-journal",
@@ -905,6 +956,7 @@
       "date": "2004",
       "year": 2004,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/KLUT2M8L",
         "type": "report",
@@ -935,6 +987,7 @@
       "title": "Modeling Travelers' Perceptions of Travel Time",
       "url": "https://onlinepubs.trb.org/Onlinepubs/trr/1982/890/890-002.pdf",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/J77LV6K7",
         "type": "article-journal",
@@ -961,6 +1014,7 @@
       "date": "2019",
       "year": 2019,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/9ANYQ3XC",
         "type": "webpage",
@@ -1003,6 +1057,7 @@
       "date": "1980",
       "year": 1980,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/GYX8EH9J",
         "type": "article-journal",
@@ -1057,6 +1112,7 @@
       "doi": "10.1002/psp.630",
       "date": "2012",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/N624WXWN",
         "type": "article-journal",
@@ -1114,6 +1170,7 @@
       "date": "1991",
       "year": 1991,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/XC9UULBH",
         "type": "chapter",
@@ -1167,6 +1224,7 @@
       "date": "2011",
       "year": 2011,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/NIC29W7V",
         "type": "chapter",
@@ -1230,6 +1288,7 @@
       "type": "chapter",
       "title": "Carto-City",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/QET6RCP2",
         "type": "chapter",
@@ -1255,6 +1314,7 @@
       "date": "1992",
       "year": 1992,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/JFZLEVU3",
         "type": "chapter",
@@ -1332,6 +1392,7 @@
       "date": "2009",
       "year": 2009,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/TWJ2KGRP",
         "type": "book",
@@ -1387,6 +1448,7 @@
         "Cognitive bias",
         "Technology and analytics"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/9S22YJNU",
         "type": "article-magazine",
@@ -1434,6 +1496,7 @@
       "date": "2017",
       "year": 2017,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/GJS2SSDQ",
         "type": "chapter",
@@ -1497,6 +1560,7 @@
       "date": "2021",
       "year": 2021,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/2JHK76L7",
         "type": "post-weblog",
@@ -1543,6 +1607,7 @@
       "tags": [
         "Negroes"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/ZA7XRIJQ",
         "type": "article-newspaper",
@@ -1590,6 +1655,7 @@
       "date": "2009",
       "year": 2009,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/APEI3Q4C",
         "type": "chapter",
@@ -1633,6 +1699,7 @@
       "tags": [
         "Land Use Change"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/6VSYCHYT",
         "type": "dataset",
@@ -1677,6 +1744,7 @@
       "date": "2024",
       "year": 2024,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/T58IBWHQ",
         "type": "article-journal",
@@ -1733,6 +1801,7 @@
         "Urban Areas",
         "internal-storyline-no"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/ERB65TU2",
         "type": "article-newspaper",
@@ -1787,6 +1856,7 @@
         "refugees",
         "transit migration"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/B9BHMNWK",
         "type": "article-journal",
@@ -1844,6 +1914,7 @@
         "Methodology",
         "Social aspects"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/G47YSBSC",
         "type": "book",
@@ -1889,6 +1960,7 @@
       "date": "2010",
       "year": 2010,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/MM3C56A5",
         "type": "chapter",
@@ -1933,6 +2005,7 @@
         "synthesis",
         "understanding"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/K54S43LG",
         "type": "book",
@@ -1980,6 +2053,7 @@
       "date": "1991",
       "year": 1991,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/9QMQDWFD",
         "type": "chapter",
@@ -2042,6 +2116,7 @@
         "GIS",
         "Movement"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/KIJKKVBT",
         "type": "article-journal",
@@ -2103,6 +2178,7 @@
         "GIS",
         "Movement"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/HWKQEKBJ",
         "type": "article-journal",
@@ -2156,6 +2232,7 @@
       "date": "2011",
       "year": 2011,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/KSH9Y8D9",
         "type": "webpage",
@@ -2207,6 +2284,7 @@
         "vehicle miles traveled (VMT)",
         "walking"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/HBAQSD3B",
         "type": "article-journal",
@@ -2263,6 +2341,7 @@
       "date": "2019",
       "year": 2019,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/U3ZGQN99",
         "type": "book",
@@ -2309,6 +2388,7 @@
       "type": "chapter",
       "title": "Spatial Data",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/ACR8UYSJ",
         "type": "chapter",
@@ -2342,6 +2422,7 @@
       "tags": [
         "uncertainty"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/TNIAXGRH",
         "type": "article-journal",
@@ -2411,6 +2492,7 @@
       "date": "1978",
       "year": 1978,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/RFBBB2TE",
         "type": "graphic",
@@ -2445,6 +2527,7 @@
       "tags": [
         "mapping-systems"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/JTEGM2U3",
         "type": "chapter",
@@ -2532,6 +2615,7 @@
       "date": "2021",
       "year": 2021,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/WNEAX6KF",
         "type": "article-journal",
@@ -2587,6 +2671,7 @@
         "Theory",
         "computer"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/AMYZ33ZV",
         "type": "article-journal",
@@ -2611,6 +2696,7 @@
       "doi": "10.1177/016001760002300201",
       "date": "2000",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/GAWPYN3I",
         "type": "article-journal",
@@ -2680,6 +2766,7 @@
         "Urbanization",
         "Vulnerability"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/34CG4EPW",
         "type": "article-journal",
@@ -2738,6 +2825,7 @@
       "date": "2023",
       "year": 2023,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/4SPT78AB",
         "type": "book",
@@ -2789,6 +2877,7 @@
       "doi": "10.2307/3178066",
       "date": "1988",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/CTAGPST9",
         "type": "article-journal",
@@ -2838,6 +2927,7 @@
       "date": "1982",
       "year": 1982,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/JJA7GGQW",
         "type": "article-journal",
@@ -2885,6 +2975,7 @@
       "title": "Hassler_1816_Sketch.jpg (1276×1481)",
       "url": "https://geodesy.noaa.gov/web/about_ngs/history/Hassler_1816_Sketch.jpg",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/LP74QRML",
         "type": "map",
@@ -2928,6 +3019,7 @@
         "meta-analysis",
         "systematic review"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/QGDFCM5T",
         "type": "article-journal",
@@ -3000,6 +3092,7 @@
         "Natural hazards",
         "Sustainability"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/6VWVPVVM",
         "type": "article-journal",
@@ -3076,6 +3169,7 @@
         "Remote sensing",
         "United States"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/FTVN9SRW",
         "type": "article-journal",
@@ -3166,6 +3260,7 @@
       "type": "article-journal",
       "title": "EDITORIAL ASSISTANTS",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/ESV5D4RL",
         "type": "article-journal",
@@ -3195,6 +3290,7 @@
       "date": "2025",
       "year": 2025,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/25FVMRF3",
         "type": "book",
@@ -3261,6 +3357,7 @@
       "date": "1978",
       "year": 1978,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/Z4WNISIG",
         "type": "article-journal",
@@ -3310,6 +3407,7 @@
       "date": "2023",
       "year": 2023,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/M77RDA79",
         "type": "article-journal",
@@ -3360,6 +3458,7 @@
       "tags": [
         "desire path"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/M4XAAABM",
         "type": "post-weblog",
@@ -3411,6 +3510,7 @@
         "pixel/object-based information integration",
         "temporal/spatial context"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/B44IGNVR",
         "type": "article-journal",
@@ -3505,6 +3605,7 @@
         "transport",
         "urban design"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/JHCY3BGZ",
         "type": "article-newspaper",
@@ -3547,6 +3648,7 @@
       "type": "chapter",
       "title": "Geography and GIS",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/9U6THMW8",
         "type": "chapter",
@@ -3568,6 +3670,7 @@
       "title": "Azimuthal Equidistant Projection (Hemispheres): Compare Map Projections",
       "url": "https://map-projections.net/single-view/azimuthal-equidistant-hemi",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/R7J8DSND",
         "type": "webpage",
@@ -3598,6 +3701,7 @@
       "title": "Lambert Cylindrical: Compare Map Projections",
       "url": "https://map-projections.net/single-view/lambert",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/Q5AN5M5T",
         "type": "webpage",
@@ -3628,6 +3732,7 @@
       "title": "Lambert conformal conic: Compare Map Projections",
       "url": "https://map-projections.net/single-view/lambert-conformal-conic",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/SFEMIXHI",
         "type": "webpage",
@@ -3658,6 +3763,7 @@
       "title": "Comparing Map Projections",
       "url": "https://bl.ocks.org/syntagmatic/ba569633d51ebec6ec6e",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/IRPBIPUW",
         "type": "webpage",
@@ -3691,6 +3797,7 @@
       "date": "2022",
       "year": 2022,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/IF4VZ88X",
         "type": "post-weblog",
@@ -3738,6 +3845,7 @@
       "date": "2020",
       "year": 2020,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/TT8D3XSS",
         "type": "article-journal",
@@ -3848,6 +3956,7 @@
       "date": "2021",
       "year": 2021,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/Q8QVLZ4I",
         "type": "webpage",
@@ -3889,6 +3998,7 @@
       "date": "1970",
       "year": 1970,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/FIK7EZU5",
         "type": "article-journal",
@@ -3941,6 +4051,7 @@
         "Case studies",
         "Computer Science - Computer Vision and Pattern Recognition"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/ZPIPTXYX",
         "type": "webpage",
@@ -3974,6 +4085,7 @@
       "date": "2020",
       "year": 2020,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/36TQX2C5",
         "type": "post-weblog",
@@ -4020,6 +4132,7 @@
       "date": "2025",
       "year": 2025,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/4E54L4ZH",
         "type": "article-journal",
@@ -4086,6 +4199,7 @@
       "date": "2005",
       "year": 2005,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/SYN8H39L",
         "type": "chapter",
@@ -4131,6 +4245,7 @@
       "date": "2014",
       "year": 2014,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/K7JTL5QV",
         "type": "webpage",
@@ -4175,6 +4290,7 @@
       "date": "1960",
       "year": 1960,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/HU2VCT28",
         "type": "chapter",
@@ -4209,6 +4325,7 @@
         "City planning",
         "United States"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/IBVUU8FQ",
         "type": "book",
@@ -4243,6 +4360,7 @@
       "date": "2006",
       "year": 2006,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/NBX5VLHA",
         "type": "chapter",
@@ -4277,6 +4395,7 @@
       "date": "2006",
       "year": 2006,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/RGHPZ9QM",
         "type": "chapter",
@@ -4312,6 +4431,7 @@
       "date": "2006",
       "year": 2006,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/WTQAZHGX",
         "type": "chapter",
@@ -4351,6 +4471,7 @@
         "Theory",
         "network analysis"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/TN7986PG",
         "type": "webpage",
@@ -4394,6 +4515,7 @@
       "date": "2012",
       "year": 2012,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/TZEFL94X",
         "type": "article-journal",
@@ -4442,6 +4564,7 @@
       "title": "A New World Map on an Irregular Heptahedron",
       "date": "2006",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/Y2KRXDB9",
         "type": "thesis",
@@ -4473,6 +4596,7 @@
       "date": "1970",
       "year": 1970,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/K8ZUNGZN",
         "type": "chapter",
@@ -4505,6 +4629,7 @@
       "date": "2019",
       "year": 2019,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/6723CRDU",
         "type": "chapter",
@@ -4535,6 +4660,7 @@
       "type": "article-journal",
       "title": "Not Yet #AfterRikers: Looking for #JusticeInDesign",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/FIZMBVCN",
         "type": "article-journal",
@@ -4560,6 +4686,7 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/YU35IK7K",
         "type": "post-weblog",
@@ -4605,6 +4732,7 @@
       "date": "2004",
       "year": 2004,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/H8CV2K3U",
         "type": "article-journal",
@@ -4651,6 +4779,7 @@
       "date": "2004",
       "year": 2004,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/ALB2T4VH",
         "type": "article-journal",
@@ -4698,6 +4827,7 @@
       "date": "1966",
       "year": 1966,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/PI9LS8K4",
         "type": "article-journal",
@@ -4746,6 +4876,7 @@
       "date": "2020",
       "year": 2020,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/YP6J6EAB",
         "type": "article-journal",
@@ -4802,6 +4933,7 @@
       "date": "2015",
       "year": 2015,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/LFWGH3G5",
         "type": "report",
@@ -4842,6 +4974,7 @@
       "doi": "10.1007/s11135-015-0228-7",
       "date": "2016",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/CFRMKKKG",
         "type": "article-journal",
@@ -4896,6 +5029,7 @@
       "type": "report",
       "title": "Basics of Mapping and GIS",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/8P95G6UT",
         "type": "report",
@@ -4919,6 +5053,7 @@
       "date": "2021",
       "year": 2021,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/CBPZSBUL",
         "type": "webpage",
@@ -4962,6 +5097,7 @@
       "date": "2023",
       "year": 2023,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/CWIW69GM",
         "type": "map",
@@ -4993,6 +5129,7 @@
       "tags": [
         "Community development-Michigan-Detroit."
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/5Y46HPVQ",
         "type": "book",
@@ -5072,6 +5209,7 @@
       "date": "2022",
       "year": 2022,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/IJVWIJDB",
         "type": "report",
@@ -5108,6 +5246,7 @@
       "tags": [
         "Computer Science - Human-Computer Interaction"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/CC5KEKSU",
         "type": "article",
@@ -5155,6 +5294,7 @@
       "date": "2017",
       "year": 2017,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/J7CDGCGL",
         "type": "post-weblog",
@@ -5202,6 +5342,7 @@
       "date": "2007",
       "year": 2007,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/2DFF9BQP",
         "type": "article-journal",
@@ -5260,6 +5401,7 @@
       "date": "2005",
       "year": 2005,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/W3MRBMBE",
         "type": "article-journal",
@@ -5315,6 +5457,7 @@
       "title": "Coordinate Reference Systems — QGIS Documentation documentation",
       "url": "https://docs.qgis.org/3.4/en/docs/gentle_gis_introduction/coordinate_reference_systems.html",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/8VIF7RL6",
         "type": "webpage",
@@ -5353,6 +5496,7 @@
         "Travel mode choice",
         "Trip distance"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/LCBL3ESN",
         "type": "article-journal",
@@ -5405,6 +5549,7 @@
       "doi": "10.1080/0269745032000168269",
       "date": "2003",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/6XR9TG3K",
         "type": "article-journal",
@@ -5468,6 +5613,7 @@
         "Sociocultural Anthropology",
         "Volunteered geographic information"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/RP4W4YBJ",
         "type": "article-journal",
@@ -5533,6 +5679,7 @@
       "date": "2022",
       "year": 2022,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/VVT2R2US",
         "type": "post-weblog",
@@ -5576,6 +5723,7 @@
       "date": "2015",
       "year": 2015,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/4XGV2K8V",
         "type": "book",
@@ -5618,6 +5766,7 @@
       "date": "1975",
       "year": 1975,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/SJXJXVXZ",
         "type": "chapter",
@@ -5669,6 +5818,7 @@
       "date": "1995",
       "year": 1995,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/GMDB9ZMD",
         "type": "article-journal",
@@ -5718,6 +5868,7 @@
         "Theory",
         "macroscope"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/RDQ7QWE2",
         "type": "article-journal",
@@ -5746,6 +5897,7 @@
       "date": "2019",
       "year": 2019,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/J7T93PLH",
         "type": "article-journal",
@@ -5804,6 +5956,7 @@
         "Science / Earth Sciences / Geology",
         "Travel / Maps & Road Atlases"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/ID639BIQ",
         "type": "book",
@@ -5840,6 +5993,7 @@
       "title": "West Philadelphia Landscape Project",
       "url": "https://wplp.net/about/",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/I4MGDNUJ",
         "type": "webpage",
@@ -5871,6 +6025,7 @@
       "date": "2010",
       "year": 2010,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/AG4VQNBU",
         "type": "chapter",
@@ -5908,6 +6063,7 @@
       "date": "2019",
       "year": 2019,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/AALTUHFG",
         "type": "post-weblog",
@@ -5951,6 +6107,7 @@
       "title": "Quarte Partie du Monde",
       "url": "https://i.pinimg.com/736x/33/07/65/330765c1b82631b8e7847a4584590802.jpg",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/S8MF5JFS",
         "type": "map",
@@ -5977,6 +6134,7 @@
       "date": "1970",
       "year": 1970,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/S5NGFGAN",
         "type": "article-journal",
@@ -6010,6 +6168,7 @@
       "date": "2012",
       "year": 2012,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/XTQMFF9Y",
         "type": "article-journal",
@@ -6043,6 +6202,7 @@
       "type": "article-journal",
       "title": "Mapping What Isn’t Quite There",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/MY9B7ABJ",
         "type": "article-journal",
@@ -6068,6 +6228,7 @@
       "date": "2021",
       "year": 2021,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/837NPBYS",
         "type": "post-weblog",
@@ -6116,6 +6277,7 @@
         "Restaurants",
         "Technology"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/KNPRXU2I",
         "type": "article-newspaper",
@@ -6183,6 +6345,7 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/9GIUHJ6Q",
         "type": "post-weblog",
@@ -6226,6 +6389,7 @@
       "date": "1975",
       "year": 1975,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/ALLRJECU",
         "type": "article-journal",
@@ -6276,6 +6440,7 @@
       "date": "2024",
       "year": 2024,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/LV5FQ6SY",
         "type": "map",
@@ -6311,6 +6476,7 @@
       "date": "2020",
       "year": 2020,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/SE5ZQI7H",
         "type": "webpage",
@@ -6362,6 +6528,7 @@
       "date": "1300",
       "year": 1300,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/JAIVT5BZ",
         "type": "map",
@@ -6393,6 +6560,7 @@
       "doi": "10.1016/j.jtrangeo.2003.10.001",
       "date": "2004",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/X83JTBX5",
         "type": "article-journal",
@@ -6452,6 +6620,7 @@
       "title": "Overview - History - National Geodetic Survey",
       "url": "https://geodesy.noaa.gov/web/about_ngs/history/",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/P93LET7K",
         "type": "webpage",
@@ -6486,6 +6655,7 @@
       "date": "2021",
       "year": 2021,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/4F63UBV4",
         "type": "map",
@@ -6519,6 +6689,7 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/DAJ9YFCW",
         "type": "article-journal",
@@ -6585,6 +6756,7 @@
       "type": "article-journal",
       "title": "Generalising spatial data and dealing with multiple representations",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/XL4BTTVI",
         "type": "article-journal",
@@ -6621,6 +6793,7 @@
         "Reference data error",
         "Stratified sampling"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/YCZSB5RT",
         "type": "article-journal",
@@ -6686,6 +6859,7 @@
       "date": "2015",
       "year": 2015,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/MU57N7TL",
         "type": "paper-conference",
@@ -6733,6 +6907,7 @@
       "date": "2018",
       "year": 2018,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/3HIZIH4C",
         "type": "chapter",
@@ -6775,6 +6950,7 @@
       "doi": "10.1177/1474474014539249",
       "date": "2015",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/E4Z8EEX5",
         "type": "article-journal",
@@ -6824,6 +7000,7 @@
       "date": "1993",
       "year": 1993,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/V998M9H4",
         "type": "article-journal",
@@ -6860,6 +7037,7 @@
         "Cartography",
         "Perception"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/36Y8EEPD",
         "type": "article-journal",
@@ -6907,6 +7085,7 @@
       "doi": "10.1016/j.cities.2022.103677",
       "date": "2022",
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/D4KH4EL3",
         "type": "article-journal",
@@ -6976,6 +7155,7 @@
         "Geodesign",
         "Spatial planning"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/ZNQFDKKP",
         "type": "article-journal",
@@ -7057,6 +7237,7 @@
         "Geodesign",
         "Spatial planning"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/IDVCI7LC",
         "type": "article-journal",
@@ -7131,6 +7312,7 @@
       "date": "2005",
       "year": 2005,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/F4GFAPKB",
         "type": "chapter",
@@ -7165,6 +7347,7 @@
         "Computer Science - Data Structures and Algorithms",
         "Data format"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/IE5M4HWQ",
         "type": "webpage",
@@ -7223,6 +7406,7 @@
         "Computer Science - Computer Vision and Pattern Recognition",
         "Computer Science - Computers and Society"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/J5NV6SH4",
         "type": "article",
@@ -7306,6 +7490,7 @@
       "tags": [
         "Dataset"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/E3CXIG4C",
         "type": "article-journal",
@@ -7374,6 +7559,7 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/2G5EL4DS",
         "type": "webpage",
@@ -7410,6 +7596,7 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/ERGXRL6C",
         "type": "webpage",
@@ -7446,6 +7633,7 @@
       "date": "2023",
       "year": 2023,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/QJ3M53BD",
         "type": "post-weblog",
@@ -7481,6 +7669,7 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/NPZQ324A",
         "type": "webpage",
@@ -7521,6 +7710,7 @@
         "Data extractivism",
         "Theory"
       ],
+      "subcollections": [],
       "csl": {
         "id": "747207/GJIDKZL5",
         "type": "document",
@@ -7545,6 +7735,7 @@
       "date": "2009",
       "year": 2009,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/BTHJG429",
         "type": "webpage",
@@ -7583,6 +7774,7 @@
       "date": "2009",
       "year": 2009,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/S2RZF8FL",
         "type": "webpage",
@@ -7616,6 +7808,7 @@
       "date": "2015",
       "year": 2015,
       "tags": [],
+      "subcollections": [],
       "csl": {
         "id": "747207/24U9NDJN",
         "type": "post-weblog",

--- a/src/data/zotero.json
+++ b/src/data/zotero.json
@@ -1,6 +1,6 @@
 {
   "style": "chicago-author-date",
-  "fetchedAt": "2026-05-16T00:47:36.043Z",
+  "fetchedAt": "2026-05-16T13:37:44.724Z",
   "collectionId": "847AR7X4",
   "count": 163,
   "subcollections": [
@@ -35,6 +35,10 @@
     {
       "key": "S3Z4ZXR8",
       "name": "design"
+    },
+    {
+      "key": "7QDS4XU2",
+      "name": "history"
     },
     {
       "key": "AGAC9I88",
@@ -229,38 +233,6 @@
       "bibtex": "\n@incollection{antrop_sensing_2017,\n\taddress = {Dordrecht},\n\ttitle = {Sensing and {Experiencing} the {Landscape}},\n\tisbn = {978-94-024-1183-6},\n\turl = {https://doi.org/10.1007/978-94-024-1183-6_6},\n\tdoi = {10.1007/978-94-024-1183-6_6},\n\tabstract = {The concept landscape implies the perception by a human observer. People sense and experience their environment holistically, using all senses simultaneously. Gestalt-principles apply here. Various disciplines study landscape perception and the mental information processing resulting in mindscapes and adapted behaviour. Several theories have been formulated to explain this process using biological, cultural and individual factors. Perception is often restricted to the visual landscape. Landscape experience refers to the whole arousal resulting from sensing the landscape. Landscape preference focuses upon the assessment we make of this experience. The properties and conditions of human vision help to understand how we analyse the landscape scenery and define basic concepts for all kinds of visualisations, as in painting, photography and computer modelling. Landscape experience research follows either an objectivist paradigm, aiming to identify physical landscape properties that can be related to preferences, or a subjectivist paradigm, focusing on the psychological and sociological response. The first one is a landscape centred approach, the second one focuses on the observer and his social and cultural background.},\n\tlanguage = {en},\n\turldate = {2024-05-16},\n\tbooktitle = {Landscape {Perspectives}: {The} {Holistic} {Nature} of {Landscape}},\n\tpublisher = {Springer Netherlands},\n\tauthor = {Antrop, Marc and Van Eetvelde, Veerle},\n\teditor = {Antrop, Marc and Van Eetvelde, Veerle},\n\tyear = {2017},\n\tkeywords = {Gestalt, Landscape preference, Perception, Visual landscape},\n\tpages = {103--139},\n}\n"
     },
     {
-      "key": "URKJDZ84",
-      "type": "chapter",
-      "title": "Graph Theory",
-      "date": "2016",
-      "year": 2016,
-      "tags": [],
-      "subcollections": [],
-      "csl": {
-        "id": "747207/URKJDZ84",
-        "type": "chapter",
-        "container-title": "Network Science",
-        "publisher": "Cambridge University Press",
-        "publisher-place": "Cambridge, United Kingdom",
-        "title": "Graph Theory",
-        "author": [
-          {
-            "family": "Barabási",
-            "given": "Albert-László"
-          }
-        ],
-        "issued": {
-          "date-parts": [
-            [
-              2016
-            ]
-          ]
-        }
-      },
-      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Barab&#xE1;si, Albert-L&#xE1;szl&#xF3;. 2016. &#x201C;Graph Theory.&#x201D; In <i>Network Science</i>. Cambridge University Press.</div>\n</div>",
-      "bibtex": "\n@incollection{barabasi_graph_2016,\n\taddress = {Cambridge, United Kingdom},\n\ttitle = {Graph {Theory}},\n\tbooktitle = {Network {Science}},\n\tpublisher = {Cambridge University Press},\n\tauthor = {Barabási, Albert-László},\n\tyear = {2016},\n}\n"
-    },
-    {
       "key": "XZ4EGKPF",
       "type": "book",
       "title": "Network science",
@@ -303,6 +275,40 @@
       },
       "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Barab&#xE1;si, Albert-L&#xE1;szl&#xF3;. 2016. <i>Network Science</i>. With M&#xE1;rton P&#xF3;sfai. Cambridge University Press.</div>\n</div>",
       "bibtex": "\n@book{barabasi_network_2016,\n\taddress = {Cambridge, United Kingdom},\n\ttitle = {Network science},\n\tisbn = {978-1-107-07626-6},\n\tabstract = {\"Networks are everywhere, from the Internet, to social networks, and the genetic networks that determine our biological existence. Illustrated throughout in full colour, this pioneering textbook, spanning a wide range of topics from physics to computer science, engineering, economics and the social sciences, introduces network science to an interdisciplinary audience. From the origins of the six degrees of separation to explaining why networks are robust to random failures, the author explores how viruses like Ebola and H1N1 spread, and why it is that our friends have more friends than we do. Using numerous real-world examples, this innovatively designed text includes clear delineation between undergraduate and graduate level material\"--Page [4] of cover.},\n\tlanguage = {eng},\n\tpublisher = {Cambridge University Press},\n\tauthor = {Barabási, Albert-László},\n\tcollaborator = {Pósfai, Márton},\n\tyear = {2016},\n\tkeywords = {Computer networks, Information networks},\n}\n"
+    },
+    {
+      "key": "URKJDZ84",
+      "type": "chapter",
+      "title": "Graph Theory",
+      "date": "2016",
+      "year": 2016,
+      "tags": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
+      "csl": {
+        "id": "747207/URKJDZ84",
+        "type": "chapter",
+        "container-title": "Network Science",
+        "publisher": "Cambridge University Press",
+        "publisher-place": "Cambridge, United Kingdom",
+        "title": "Graph Theory",
+        "author": [
+          {
+            "family": "Barabási",
+            "given": "Albert-László"
+          }
+        ],
+        "issued": {
+          "date-parts": [
+            [
+              2016
+            ]
+          ]
+        }
+      },
+      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Barab&#xE1;si, Albert-L&#xE1;szl&#xF3;. 2016. &#x201C;Graph Theory.&#x201D; In <i>Network Science</i>. Cambridge University Press.</div>\n</div>",
+      "bibtex": "\n@incollection{barabasi_graph_2016,\n\taddress = {Cambridge, United Kingdom},\n\ttitle = {Graph {Theory}},\n\tbooktitle = {Network {Science}},\n\tpublisher = {Cambridge University Press},\n\tauthor = {Barabási, Albert-László},\n\tyear = {2016},\n}\n"
     },
     {
       "key": "7IIFNURW",
@@ -474,7 +480,10 @@
       "date": "2012",
       "year": 2012,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "AGAC9I88",
+        "ERJ92FM8"
+      ],
       "csl": {
         "id": "747207/6ZU3JYPM",
         "type": "article-journal",
@@ -513,7 +522,9 @@
       "date": "1999",
       "year": 1999,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/4CQGLS4X",
         "type": "chapter",
@@ -595,7 +606,9 @@
       "date": "2023",
       "year": 2023,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "XNQNE959"
+      ],
       "csl": {
         "id": "747207/6NNGGHNH",
         "type": "webpage",
@@ -717,7 +730,10 @@
       "title": "Field Notes No. 1: The Detroit Geographical Expedition",
       "date": "1969",
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q",
+        "IKQFRT6Z"
+      ],
       "csl": {
         "id": "747207/QHXQJALL",
         "type": "report",
@@ -748,7 +764,10 @@
       "date": "1972",
       "year": 1972,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q",
+        "IKQFRT6Z"
+      ],
       "csl": {
         "id": "747207/7MAJ2AI4",
         "type": "report",
@@ -783,7 +802,10 @@
       "date": "1971",
       "year": 1971,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q",
+        "IKQFRT6Z"
+      ],
       "csl": {
         "id": "747207/J3CARVV2",
         "type": "report",
@@ -822,7 +844,10 @@
       "date": "1970",
       "year": 1970,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q",
+        "IKQFRT6Z"
+      ],
       "csl": {
         "id": "747207/ZR82EC99",
         "type": "report",
@@ -1026,7 +1051,9 @@
       "title": "Modeling Travelers' Perceptions of Travel Time",
       "url": "https://onlinepubs.trb.org/Onlinepubs/trr/1982/890/890-002.pdf",
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/J77LV6K7",
         "type": "article-journal",
@@ -1053,7 +1080,10 @@
       "date": "2019",
       "year": 2019,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "PGTZV2GX",
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/9ANYQ3XC",
         "type": "webpage",
@@ -1096,7 +1126,9 @@
       "date": "1980",
       "year": 1980,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/GYX8EH9J",
         "type": "article-journal",
@@ -1151,7 +1183,9 @@
       "doi": "10.1002/psp.630",
       "date": "2012",
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/N624WXWN",
         "type": "article-journal",
@@ -1263,7 +1297,9 @@
       "date": "2011",
       "year": 2011,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/NIC29W7V",
         "type": "chapter",
@@ -1538,7 +1574,9 @@
       "date": "2017",
       "year": 2017,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/GJS2SSDQ",
         "type": "chapter",
@@ -1649,7 +1687,9 @@
       "tags": [
         "Negroes"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "7QDS4XU2"
+      ],
       "csl": {
         "id": "747207/ZA7XRIJQ",
         "type": "article-newspaper",
@@ -1697,7 +1737,9 @@
       "date": "2009",
       "year": 2009,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "XNQNE959"
+      ],
       "csl": {
         "id": "747207/APEI3Q4C",
         "type": "chapter",
@@ -1741,7 +1783,9 @@
       "tags": [
         "Land Use Change"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "ERJ92FM8"
+      ],
       "csl": {
         "id": "747207/6VSYCHYT",
         "type": "dataset",
@@ -1900,7 +1944,9 @@
         "refugees",
         "transit migration"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/B9BHMNWK",
         "type": "article-journal",
@@ -2051,7 +2097,9 @@
         "synthesis",
         "understanding"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/K54S43LG",
         "type": "book",
@@ -2099,7 +2147,9 @@
       "date": "1991",
       "year": 1991,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/9QMQDWFD",
         "type": "chapter",
@@ -2147,68 +2197,6 @@
       "bibtex": "\n@incollection{entrikin_betweenness_1991,\n\taddress = {London},\n\ttitle = {The {Betweenness} of {Place}},\n\tisbn = {978-1-349-21086-2},\n\turl = {https://doi.org/10.1007/978-1-349-21086-2_2},\n\tdoi = {10.1007/978-1-349-21086-2_2},\n\tabstract = {The geographer’s concept of specific place draws attention to the relation between particularizing and universalizing discourses and between subjective and objective perspectives. Specific place refers to the conceptual fusion of space and experience that gives areas of the earth’s surface a “wholeness” or an “individuality.” I shall introduce this concept by first offering a general overview of the idea of place as context, a view that incorporates both the existential qualities of our experience of place and also our sense of place as a natural “object” in the world. This dualistic quality of place has been at the center of the conception of geography as a chorological science that addresses the relationship of people to their environment.},\n\tlanguage = {en},\n\turldate = {2024-05-19},\n\tbooktitle = {The {Betweenness} of {Place}: {Towards} a {Geography} of {Modernity}},\n\tpublisher = {Macmillan Education UK},\n\tauthor = {Entrikin, J. Nicholas},\n\teditor = {Entrikin, J. Nicholas},\n\tyear = {1991},\n\tpages = {6--26},\n}\n"
     },
     {
-      "key": "KIJKKVBT",
-      "type": "article-journal",
-      "title": "Least-Cost Modelling and Landscape Ecology: Concepts, Applications, and Opportunities",
-      "url": "https://doi.org/10.1007/s40823-016-0006-9",
-      "doi": "10.1007/s40823-016-0006-9",
-      "date": "2016",
-      "year": 2016,
-      "tags": [
-        "Connectivity",
-        "Cost-distance",
-        "Dispersal",
-        "Distance",
-        "GIS",
-        "Movement"
-      ],
-      "subcollections": [],
-      "csl": {
-        "id": "747207/KIJKKVBT",
-        "type": "article-journal",
-        "abstract": "The concept of nearness and that nearer things are more connected is useful in quantifying a variety of geographical patterns and processes, including ecological connectivity between geographic locations. In some ecological systems connectivity does not follow nearness relations defined by Euclidean distances, so distance must be measured another way. Least-cost modelling is a technique that can incorporate traversal costs across a landscape to measure the least-cost distance between locations as a function of both the distance travelled and the costs traversed. There has been a significant increase in the interest and use of least-cost modelling by ecologists in the last decade. However, perhaps because early applications of least-cost modelling in ecology tended to cite the method with reference to geographic information system software rather than the geographical science literature, ecologists are not currently making full use of available least-cost modelling techniques that have continued to develop. This review aims to describe the concepts of least-cost modelling, demonstrate current applications of least-cost modelling in landscape ecology, and to suggest future opportunities by linking the ecological application of least-cost modelling with recent geographical science developments from which least-cost modelling originally developed.",
-        "container-title": "Current Landscape Ecology Reports",
-        "DOI": "10.1007/s40823-016-0006-9",
-        "ISSN": "2364-494X",
-        "issue": "1",
-        "journalAbbreviation": "Curr Landscape Ecol Rep",
-        "language": "en",
-        "page": "40-53",
-        "shortTitle": "Least-Cost Modelling and Landscape Ecology",
-        "source": "Springer Link",
-        "title": "Least-Cost Modelling and Landscape Ecology: Concepts, Applications, and Opportunities",
-        "title-short": "Least-Cost Modelling and Landscape Ecology",
-        "URL": "https://doi.org/10.1007/s40823-016-0006-9",
-        "volume": "1",
-        "author": [
-          {
-            "family": "Etherington",
-            "given": "Thomas R."
-          }
-        ],
-        "accessed": {
-          "date-parts": [
-            [
-              2024,
-              6,
-              29
-            ]
-          ]
-        },
-        "issued": {
-          "date-parts": [
-            [
-              2016,
-              3,
-              1
-            ]
-          ]
-        }
-      },
-      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Etherington, Thomas R. 2016. &#x201C;Least-Cost Modelling and Landscape Ecology: Concepts, Applications, and Opportunities.&#x201D; <i>Current Landscape Ecology Reports</i> 1 (1): 40&#x2013;53. https://doi.org/10.1007/s40823-016-0006-9.</div>\n</div>",
-      "bibtex": "\n@article{etherington_least-cost_2016,\n\ttitle = {Least-{Cost} {Modelling} and {Landscape} {Ecology}: {Concepts}, {Applications}, and {Opportunities}},\n\tvolume = {1},\n\tissn = {2364-494X},\n\tshorttitle = {Least-{Cost} {Modelling} and {Landscape} {Ecology}},\n\turl = {https://doi.org/10.1007/s40823-016-0006-9},\n\tdoi = {10.1007/s40823-016-0006-9},\n\tabstract = {The concept of nearness and that nearer things are more connected is useful in quantifying a variety of geographical patterns and processes, including ecological connectivity between geographic locations. In some ecological systems connectivity does not follow nearness relations defined by Euclidean distances, so distance must be measured another way. Least-cost modelling is a technique that can incorporate traversal costs across a landscape to measure the least-cost distance between locations as a function of both the distance travelled and the costs traversed. There has been a significant increase in the interest and use of least-cost modelling by ecologists in the last decade. However, perhaps because early applications of least-cost modelling in ecology tended to cite the method with reference to geographic information system software rather than the geographical science literature, ecologists are not currently making full use of available least-cost modelling techniques that have continued to develop. This review aims to describe the concepts of least-cost modelling, demonstrate current applications of least-cost modelling in landscape ecology, and to suggest future opportunities by linking the ecological application of least-cost modelling with recent geographical science developments from which least-cost modelling originally developed.},\n\tlanguage = {en},\n\tnumber = {1},\n\turldate = {2024-06-29},\n\tjournal = {Current Landscape Ecology Reports},\n\tauthor = {Etherington, Thomas R.},\n\tmonth = mar,\n\tyear = {2016},\n\tkeywords = {Connectivity, Cost-distance, Dispersal, Distance, GIS, Movement},\n\tpages = {40--53},\n}\n"
-    },
-    {
       "key": "HWKQEKBJ",
       "type": "article-journal",
       "title": "Least-Cost Modelling and Landscape Ecology: Concepts, Applications, and Opportunities",
@@ -2224,7 +2212,9 @@
         "GIS",
         "Movement"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/HWKQEKBJ",
         "type": "article-journal",
@@ -2269,6 +2259,71 @@
       },
       "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Etherington, Thomas R. 2016. &#x201C;Least-Cost Modelling and Landscape Ecology: Concepts, Applications, and Opportunities.&#x201D; <i>Current Landscape Ecology Reports</i> 1 (1): 40&#x2013;53. https://doi.org/10.1007/s40823-016-0006-9.</div>\n</div>",
       "bibtex": "\n@article{etherington_least-cost_2016,\n\ttitle = {Least-{Cost} {Modelling} and {Landscape} {Ecology}: {Concepts}, {Applications}, and {Opportunities}},\n\tvolume = {1},\n\tissn = {2364-494X},\n\tshorttitle = {Least-{Cost} {Modelling} and {Landscape} {Ecology}},\n\turl = {https://doi.org/10.1007/s40823-016-0006-9},\n\tdoi = {10.1007/s40823-016-0006-9},\n\tabstract = {The concept of nearness and that nearer things are more connected is useful in quantifying a variety of geographical patterns and processes, including ecological connectivity between geographic locations. In some ecological systems connectivity does not follow nearness relations defined by Euclidean distances, so distance must be measured another way. Least-cost modelling is a technique that can incorporate traversal costs across a landscape to measure the least-cost distance between locations as a function of both the distance travelled and the costs traversed. There has been a significant increase in the interest and use of least-cost modelling by ecologists in the last decade. However, perhaps because early applications of least-cost modelling in ecology tended to cite the method with reference to geographic information system software rather than the geographical science literature, ecologists are not currently making full use of available least-cost modelling techniques that have continued to develop. This review aims to describe the concepts of least-cost modelling, demonstrate current applications of least-cost modelling in landscape ecology, and to suggest future opportunities by linking the ecological application of least-cost modelling with recent geographical science developments from which least-cost modelling originally developed.},\n\tlanguage = {en},\n\tnumber = {1},\n\turldate = {2024-08-27},\n\tjournal = {Current Landscape Ecology Reports},\n\tauthor = {Etherington, Thomas R.},\n\tmonth = mar,\n\tyear = {2016},\n\tkeywords = {Connectivity, Cost-distance, Dispersal, Distance, GIS, Movement},\n\tpages = {40--53},\n}\n"
+    },
+    {
+      "key": "KIJKKVBT",
+      "type": "article-journal",
+      "title": "Least-Cost Modelling and Landscape Ecology: Concepts, Applications, and Opportunities",
+      "url": "https://doi.org/10.1007/s40823-016-0006-9",
+      "doi": "10.1007/s40823-016-0006-9",
+      "date": "2016",
+      "year": 2016,
+      "tags": [
+        "Connectivity",
+        "Cost-distance",
+        "Dispersal",
+        "Distance",
+        "GIS",
+        "Movement"
+      ],
+      "subcollections": [
+        "6SPRPNXF",
+        "ERJ92FM8"
+      ],
+      "csl": {
+        "id": "747207/KIJKKVBT",
+        "type": "article-journal",
+        "abstract": "The concept of nearness and that nearer things are more connected is useful in quantifying a variety of geographical patterns and processes, including ecological connectivity between geographic locations. In some ecological systems connectivity does not follow nearness relations defined by Euclidean distances, so distance must be measured another way. Least-cost modelling is a technique that can incorporate traversal costs across a landscape to measure the least-cost distance between locations as a function of both the distance travelled and the costs traversed. There has been a significant increase in the interest and use of least-cost modelling by ecologists in the last decade. However, perhaps because early applications of least-cost modelling in ecology tended to cite the method with reference to geographic information system software rather than the geographical science literature, ecologists are not currently making full use of available least-cost modelling techniques that have continued to develop. This review aims to describe the concepts of least-cost modelling, demonstrate current applications of least-cost modelling in landscape ecology, and to suggest future opportunities by linking the ecological application of least-cost modelling with recent geographical science developments from which least-cost modelling originally developed.",
+        "container-title": "Current Landscape Ecology Reports",
+        "DOI": "10.1007/s40823-016-0006-9",
+        "ISSN": "2364-494X",
+        "issue": "1",
+        "journalAbbreviation": "Curr Landscape Ecol Rep",
+        "language": "en",
+        "page": "40-53",
+        "shortTitle": "Least-Cost Modelling and Landscape Ecology",
+        "source": "Springer Link",
+        "title": "Least-Cost Modelling and Landscape Ecology: Concepts, Applications, and Opportunities",
+        "title-short": "Least-Cost Modelling and Landscape Ecology",
+        "URL": "https://doi.org/10.1007/s40823-016-0006-9",
+        "volume": "1",
+        "author": [
+          {
+            "family": "Etherington",
+            "given": "Thomas R."
+          }
+        ],
+        "accessed": {
+          "date-parts": [
+            [
+              2024,
+              6,
+              29
+            ]
+          ]
+        },
+        "issued": {
+          "date-parts": [
+            [
+              2016,
+              3,
+              1
+            ]
+          ]
+        }
+      },
+      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Etherington, Thomas R. 2016. &#x201C;Least-Cost Modelling and Landscape Ecology: Concepts, Applications, and Opportunities.&#x201D; <i>Current Landscape Ecology Reports</i> 1 (1): 40&#x2013;53. https://doi.org/10.1007/s40823-016-0006-9.</div>\n</div>",
+      "bibtex": "\n@article{etherington_least-cost_2016,\n\ttitle = {Least-{Cost} {Modelling} and {Landscape} {Ecology}: {Concepts}, {Applications}, and {Opportunities}},\n\tvolume = {1},\n\tissn = {2364-494X},\n\tshorttitle = {Least-{Cost} {Modelling} and {Landscape} {Ecology}},\n\turl = {https://doi.org/10.1007/s40823-016-0006-9},\n\tdoi = {10.1007/s40823-016-0006-9},\n\tabstract = {The concept of nearness and that nearer things are more connected is useful in quantifying a variety of geographical patterns and processes, including ecological connectivity between geographic locations. In some ecological systems connectivity does not follow nearness relations defined by Euclidean distances, so distance must be measured another way. Least-cost modelling is a technique that can incorporate traversal costs across a landscape to measure the least-cost distance between locations as a function of both the distance travelled and the costs traversed. There has been a significant increase in the interest and use of least-cost modelling by ecologists in the last decade. However, perhaps because early applications of least-cost modelling in ecology tended to cite the method with reference to geographic information system software rather than the geographical science literature, ecologists are not currently making full use of available least-cost modelling techniques that have continued to develop. This review aims to describe the concepts of least-cost modelling, demonstrate current applications of least-cost modelling in landscape ecology, and to suggest future opportunities by linking the ecological application of least-cost modelling with recent geographical science developments from which least-cost modelling originally developed.},\n\tlanguage = {en},\n\tnumber = {1},\n\turldate = {2024-06-29},\n\tjournal = {Current Landscape Ecology Reports},\n\tauthor = {Etherington, Thomas R.},\n\tmonth = mar,\n\tyear = {2016},\n\tkeywords = {Connectivity, Cost-distance, Dispersal, Distance, GIS, Movement},\n\tpages = {40--53},\n}\n"
     },
     {
       "key": "KSH9Y8D9",
@@ -2330,7 +2385,9 @@
         "vehicle miles traveled (VMT)",
         "walking"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/HBAQSD3B",
         "type": "article-journal",
@@ -2668,7 +2725,11 @@
       "date": "2021",
       "year": 2021,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q",
+        "IKQFRT6Z",
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/WNEAX6KF",
         "type": "article-journal",
@@ -2935,7 +2996,9 @@
       "doi": "10.2307/3178066",
       "date": "1988",
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q"
+      ],
       "csl": {
         "id": "747207/CTAGPST9",
         "type": "article-journal",
@@ -2985,7 +3048,9 @@
       "date": "1982",
       "year": 1982,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/JJA7GGQW",
         "type": "article-journal",
@@ -4069,7 +4134,9 @@
       "date": "1970",
       "year": 1970,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/FIK7EZU5",
         "type": "article-journal",
@@ -4363,38 +4430,6 @@
       "bibtex": "\n@misc{lucarelli_ascii-art_2014,\n\ttitle = {Ascii-{Art} {Mapping}: {SyMAP} (or {Early} {Computer} {Generated} {Cartography}) – {SOCKS}},\n\tshorttitle = {Ascii-{Art} {Mapping}},\n\turl = {https://socks-studio.com/2014/03/11/ascii-art-mapping-symap-or-early-computer-generated-cartography/, https://socks-studio.com/2014/03/11/ascii-art-mapping-symap-or-early-computer-generated-cartography/},\n\tabstract = {William Caraher, assistant professor at the University of North Dakota and writer of the site \"The Archaeology of the Mediterranean World\" discovered an interesting early use...},\n\tlanguage = {en-US},\n\turldate = {2024-05-13},\n\tauthor = {Lucarelli, Fosco},\n\tmonth = mar,\n\tyear = {2014},\n}\n"
     },
     {
-      "key": "HU2VCT28",
-      "type": "chapter",
-      "title": "The city and its elements",
-      "date": "1960",
-      "year": 1960,
-      "tags": [],
-      "subcollections": [],
-      "csl": {
-        "id": "747207/HU2VCT28",
-        "type": "chapter",
-        "container-title": "The image of the city",
-        "publisher": "The MIT Press",
-        "publisher-place": "Cambridge MA",
-        "title": "The city and its elements",
-        "author": [
-          {
-            "family": "Lynch",
-            "given": "Kevin"
-          }
-        ],
-        "issued": {
-          "date-parts": [
-            [
-              1960
-            ]
-          ]
-        }
-      },
-      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Lynch, Kevin. 1960. &#x201C;The City and Its Elements.&#x201D; In <i>The Image of the City</i>. The MIT Press.</div>\n</div>",
-      "bibtex": "\n@incollection{lynch_city_1960,\n\taddress = {Cambridge MA},\n\ttitle = {The city and its elements},\n\tbooktitle = {The image of the city},\n\tpublisher = {The MIT Press},\n\tauthor = {Lynch, Kevin},\n\tyear = {1960},\n}\n"
-    },
-    {
       "key": "IBVUU8FQ",
       "type": "book",
       "title": "The image of the city",
@@ -4433,40 +4468,38 @@
       "bibtex": "\n@book{lynch_image_1960,\n\taddress = {Cambridge, Massachusetts ; London, England},\n\ttitle = {The image of the city},\n\tisbn = {978-0-262-12004-3 978-0-262-62001-7},\n\tpublisher = {The MIT Press, Massachusetts Institute of Technology},\n\tauthor = {Lynch, Kevin},\n\tyear = {1960},\n\tkeywords = {City planning, United States},\n}\n"
     },
     {
-      "key": "RGHPZ9QM",
+      "key": "HU2VCT28",
       "type": "chapter",
-      "title": "Thematic Mapping",
-      "date": "2006",
-      "year": 2006,
+      "title": "The city and its elements",
+      "date": "1960",
+      "year": 1960,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
-        "id": "747207/RGHPZ9QM",
+        "id": "747207/HU2VCT28",
         "type": "chapter",
-        "container-title": "GIS for the Urban Environment",
-        "ISBN": "978-1-58948-082-7",
-        "publisher": "ESRI Press",
-        "title": "Thematic Mapping",
+        "container-title": "The image of the city",
+        "publisher": "The MIT Press",
+        "publisher-place": "Cambridge MA",
+        "title": "The city and its elements",
         "author": [
           {
-            "family": "Maantay",
-            "given": "Juliana"
-          },
-          {
-            "family": "Ziegler",
-            "given": "John"
+            "family": "Lynch",
+            "given": "Kevin"
           }
         ],
         "issued": {
           "date-parts": [
             [
-              2006
+              1960
             ]
           ]
         }
       },
-      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Maantay, Juliana, and John Ziegler. 2006. &#x201C;Thematic Mapping.&#x201D; In <i>GIS for the Urban Environment</i>. ESRI Press.</div>\n</div>",
-      "bibtex": "\n@incollection{maantay_thematic_2006,\n\ttitle = {Thematic {Mapping}},\n\tisbn = {978-1-58948-082-7},\n\tbooktitle = {{GIS} for the {Urban} {Environment}},\n\tpublisher = {ESRI Press},\n\tauthor = {Maantay, Juliana and Ziegler, John},\n\tyear = {2006},\n}\n"
+      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Lynch, Kevin. 1960. &#x201C;The City and Its Elements.&#x201D; In <i>The Image of the City</i>. The MIT Press.</div>\n</div>",
+      "bibtex": "\n@incollection{lynch_city_1960,\n\taddress = {Cambridge MA},\n\ttitle = {The city and its elements},\n\tbooktitle = {The image of the city},\n\tpublisher = {The MIT Press},\n\tauthor = {Lynch, Kevin},\n\tyear = {1960},\n}\n"
     },
     {
       "key": "WTQAZHGX",
@@ -4539,6 +4572,44 @@
       },
       "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Maantay, Juliana, and John Ziegler. 2006. &#x201C;Ch 9: Methods of Spatial Data Analysis.&#x201D; In <i>GIS for the Urban Environment</i>.</div>\n</div>",
       "bibtex": "\n@incollection{maantay_ch_2006,\n\ttitle = {Ch 9: {Methods} of {Spatial} {Data} {Analysis}},\n\tbooktitle = {{GIS} for the {Urban} {Environment}},\n\tauthor = {Maantay, Juliana and Ziegler, John},\n\tyear = {2006},\n\tnote = {required},\n}\n"
+    },
+    {
+      "key": "RGHPZ9QM",
+      "type": "chapter",
+      "title": "Thematic Mapping",
+      "date": "2006",
+      "year": 2006,
+      "tags": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
+      "csl": {
+        "id": "747207/RGHPZ9QM",
+        "type": "chapter",
+        "container-title": "GIS for the Urban Environment",
+        "ISBN": "978-1-58948-082-7",
+        "publisher": "ESRI Press",
+        "title": "Thematic Mapping",
+        "author": [
+          {
+            "family": "Maantay",
+            "given": "Juliana"
+          },
+          {
+            "family": "Ziegler",
+            "given": "John"
+          }
+        ],
+        "issued": {
+          "date-parts": [
+            [
+              2006
+            ]
+          ]
+        }
+      },
+      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Maantay, Juliana, and John Ziegler. 2006. &#x201C;Thematic Mapping.&#x201D; In <i>GIS for the Urban Environment</i>. ESRI Press.</div>\n</div>",
+      "bibtex": "\n@incollection{maantay_thematic_2006,\n\ttitle = {Thematic {Mapping}},\n\tisbn = {978-1-58948-082-7},\n\tbooktitle = {{GIS} for the {Urban} {Environment}},\n\tpublisher = {ESRI Press},\n\tauthor = {Maantay, Juliana and Ziegler, John},\n\tyear = {2006},\n}\n"
     },
     {
       "key": "TN7986PG",
@@ -4682,7 +4753,9 @@
       "date": "1970",
       "year": 1970,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/K8ZUNGZN",
         "type": "chapter",
@@ -4814,53 +4887,6 @@
       "bibtex": "\n@misc{migurski_weeknotes_2026,\n\ttitle = {Weeknotes, {2026W04}: {Boundary} {Issues}},\n\tshorttitle = {Weeknotes, {2026W04}},\n\turl = {https://medium.com/@michalmigurski/weeknotes-2026w04-boundary-issues-f037407a7f45},\n\tabstract = {I recently nerd-sniped myself into thinking about political points of view on maps, and wondering whether it’d be possible to create…},\n\turldate = {2026-02-03},\n\tjournal = {Medium},\n\tauthor = {Migurski, Michal},\n\tmonth = feb,\n\tyear = {2026},\n}\n"
     },
     {
-      "key": "H8CV2K3U",
-      "type": "article-journal",
-      "title": "Tobler's First Law and Spatial Analysis",
-      "url": "https://www.jstor.org/stable/3693985",
-      "date": "2004",
-      "year": 2004,
-      "tags": [],
-      "subcollections": [],
-      "csl": {
-        "id": "747207/H8CV2K3U",
-        "type": "article-journal",
-        "container-title": "Annals of the Association of American Geographers",
-        "ISSN": "0004-5608",
-        "issue": "2",
-        "page": "284-289",
-        "publisher": "[Association of American Geographers, Taylor & Francis, Ltd.]",
-        "source": "JSTOR",
-        "title": "Tobler's First Law and Spatial Analysis",
-        "URL": "https://www.jstor.org/stable/3693985",
-        "volume": "94",
-        "author": [
-          {
-            "family": "Miller",
-            "given": "Harvey J."
-          }
-        ],
-        "accessed": {
-          "date-parts": [
-            [
-              2022,
-              10,
-              6
-            ]
-          ]
-        },
-        "issued": {
-          "date-parts": [
-            [
-              2004
-            ]
-          ]
-        }
-      },
-      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Miller, Harvey J. 2004. &#x201C;Tobler&#x2019;s First Law and Spatial Analysis.&#x201D; <i>Annals of the Association of American Geographers</i> 94 (2): 284&#x2013;89. https://www.jstor.org/stable/3693985.</div>\n</div>",
-      "bibtex": "\n@article{miller_toblers_2004,\n\ttitle = {Tobler's {First} {Law} and {Spatial} {Analysis}},\n\tvolume = {94},\n\tissn = {0004-5608},\n\turl = {https://www.jstor.org/stable/3693985},\n\tnumber = {2},\n\turldate = {2022-10-06},\n\tjournal = {Annals of the Association of American Geographers},\n\tpublisher = {[Association of American Geographers, Taylor \\& Francis, Ltd.]},\n\tauthor = {Miller, Harvey J.},\n\tyear = {2004},\n\tpages = {284--289},\n}\n"
-    },
-    {
       "key": "ALB2T4VH",
       "type": "article-journal",
       "title": "Tobler's First Law and Spatial Analysis",
@@ -4868,7 +4894,9 @@
       "date": "2004",
       "year": 2004,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/ALB2T4VH",
         "type": "article-journal",
@@ -4906,6 +4934,55 @@
       },
       "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Miller, Harvey J. 2004. &#x201C;Tobler&#x2019;s First Law and Spatial Analysis.&#x201D; <i>Annals of the Association of American Geographers</i> 94 (2): 284&#x2013;89. https://www.jstor.org/stable/3693985.</div>\n</div>",
       "bibtex": "\n@article{miller_toblers_2004,\n\ttitle = {Tobler's {First} {Law} and {Spatial} {Analysis}},\n\tvolume = {94},\n\tissn = {0004-5608},\n\turl = {https://www.jstor.org/stable/3693985},\n\tnumber = {2},\n\turldate = {2024-05-21},\n\tjournal = {Annals of the Association of American Geographers},\n\tpublisher = {[Association of American Geographers, Taylor \\& Francis, Ltd.]},\n\tauthor = {Miller, Harvey J.},\n\tyear = {2004},\n\tpages = {284--289},\n}\n"
+    },
+    {
+      "key": "H8CV2K3U",
+      "type": "article-journal",
+      "title": "Tobler's First Law and Spatial Analysis",
+      "url": "https://www.jstor.org/stable/3693985",
+      "date": "2004",
+      "year": 2004,
+      "tags": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
+      "csl": {
+        "id": "747207/H8CV2K3U",
+        "type": "article-journal",
+        "container-title": "Annals of the Association of American Geographers",
+        "ISSN": "0004-5608",
+        "issue": "2",
+        "page": "284-289",
+        "publisher": "[Association of American Geographers, Taylor & Francis, Ltd.]",
+        "source": "JSTOR",
+        "title": "Tobler's First Law and Spatial Analysis",
+        "URL": "https://www.jstor.org/stable/3693985",
+        "volume": "94",
+        "author": [
+          {
+            "family": "Miller",
+            "given": "Harvey J."
+          }
+        ],
+        "accessed": {
+          "date-parts": [
+            [
+              2022,
+              10,
+              6
+            ]
+          ]
+        },
+        "issued": {
+          "date-parts": [
+            [
+              2004
+            ]
+          ]
+        }
+      },
+      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Miller, Harvey J. 2004. &#x201C;Tobler&#x2019;s First Law and Spatial Analysis.&#x201D; <i>Annals of the Association of American Geographers</i> 94 (2): 284&#x2013;89. https://www.jstor.org/stable/3693985.</div>\n</div>",
+      "bibtex": "\n@article{miller_toblers_2004,\n\ttitle = {Tobler's {First} {Law} and {Spatial} {Analysis}},\n\tvolume = {94},\n\tissn = {0004-5608},\n\turl = {https://www.jstor.org/stable/3693985},\n\tnumber = {2},\n\turldate = {2022-10-06},\n\tjournal = {Annals of the Association of American Geographers},\n\tpublisher = {[Association of American Geographers, Taylor \\& Francis, Ltd.]},\n\tauthor = {Miller, Harvey J.},\n\tyear = {2004},\n\tpages = {284--289},\n}\n"
     },
     {
       "key": "PI9LS8K4",
@@ -5222,6 +5299,7 @@
         "Community development-Michigan-Detroit."
       ],
       "subcollections": [
+        "G32ZL73Q",
         "IKQFRT6Z",
         "T3AL7PGA"
       ],
@@ -5341,7 +5419,9 @@
       "tags": [
         "Computer Science - Human-Computer Interaction"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/CC5KEKSU",
         "type": "article",
@@ -5389,7 +5469,10 @@
       "date": "2017",
       "year": 2017,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q",
+        "IKQFRT6Z"
+      ],
       "csl": {
         "id": "747207/J7CDGCGL",
         "type": "post-weblog",
@@ -5496,7 +5579,9 @@
       "date": "2005",
       "year": 2005,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/W3MRBMBE",
         "type": "article-journal",
@@ -5591,7 +5676,9 @@
         "Travel mode choice",
         "Trip distance"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/LCBL3ESN",
         "type": "article-journal",
@@ -5777,7 +5864,9 @@
       "date": "2022",
       "year": 2022,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "ERJ92FM8"
+      ],
       "csl": {
         "id": "747207/VVT2R2US",
         "type": "post-weblog",
@@ -5864,7 +5953,10 @@
       "date": "1975",
       "year": 1975,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF",
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/SJXJXVXZ",
         "type": "chapter",
@@ -5916,7 +6008,9 @@
       "date": "1995",
       "year": 1995,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/GMDB9ZMD",
         "type": "article-journal",
@@ -5997,7 +6091,9 @@
       "date": "2019",
       "year": 2019,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/J7T93PLH",
         "type": "article-journal",
@@ -6130,7 +6226,9 @@
       "date": "2010",
       "year": 2010,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/AG4VQNBU",
         "type": "chapter",
@@ -6168,7 +6266,9 @@
       "date": "2019",
       "year": 2019,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "7QDS4XU2"
+      ],
       "csl": {
         "id": "747207/AALTUHFG",
         "type": "post-weblog",
@@ -6309,7 +6409,9 @@
       "type": "article-journal",
       "title": "Mapping What Isn’t Quite There",
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/MY9B7ABJ",
         "type": "article-journal",
@@ -6907,7 +7009,9 @@
         "Reference data error",
         "Stratified sampling"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "ERJ92FM8"
+      ],
       "csl": {
         "id": "747207/YCZSB5RT",
         "type": "article-journal",
@@ -7440,7 +7544,9 @@
       "date": "2005",
       "year": 2005,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/F4GFAPKB",
         "type": "chapter",

--- a/src/data/zotero.json
+++ b/src/data/zotero.json
@@ -1,6 +1,6 @@
 {
   "style": "chicago-author-date",
-  "fetchedAt": "2026-05-16T00:36:10.451Z",
+  "fetchedAt": "2026-05-16T00:47:36.043Z",
   "collectionId": "847AR7X4",
   "count": 163,
   "subcollections": [
@@ -10,11 +10,31 @@
     },
     {
       "key": "PGTZV2GX",
-      "name": "cartography + visualization"
+      "name": "cartography + visualization + visual references"
     },
     {
       "key": "T3AL7PGA",
       "name": "case studies"
+    },
+    {
+      "key": "IKQFRT6Z",
+      "name": "community"
+    },
+    {
+      "key": "UXN7JR59",
+      "name": "conflict"
+    },
+    {
+      "key": "G32ZL73Q",
+      "name": "critical cartography"
+    },
+    {
+      "key": "9DXPI4J7",
+      "name": "data formats + tools"
+    },
+    {
+      "key": "S3Z4ZXR8",
+      "name": "design"
     },
     {
       "key": "AGAC9I88",
@@ -29,8 +49,20 @@
       "name": "networks"
     },
     {
+      "key": "XNQNE959",
+      "name": "projections"
+    },
+    {
       "key": "DRE4ZF6F",
       "name": "theory"
+    },
+    {
+      "key": "ZZJNKMSU",
+      "name": "uncertainty"
+    },
+    {
+      "key": "E2HWAZRJ",
+      "name": "web mapping"
     }
   ],
   "entries": [
@@ -279,7 +311,9 @@
       "date": "2011",
       "year": 2011,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "PGTZV2GX"
+      ],
       "csl": {
         "id": "747207/7IIFNURW",
         "type": "book",
@@ -517,7 +551,9 @@
       "date": "2025",
       "year": 2025,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "PGTZV2GX"
+      ],
       "csl": {
         "id": "747207/VG5HM3A5",
         "type": "book",
@@ -891,7 +927,10 @@
         "Environmental social sciences",
         "Mathematics and computing"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "ERJ92FM8",
+        "UP4V2S7X"
+      ],
       "csl": {
         "id": "747207/9KGZ5VSV",
         "type": "article-journal",
@@ -1392,7 +1431,10 @@
       "date": "2009",
       "year": 2009,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F",
+        "E2HWAZRJ"
+      ],
       "csl": {
         "id": "747207/TWJ2KGRP",
         "type": "book",
@@ -1801,7 +1843,9 @@
         "Urban Areas",
         "internal-storyline-no"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/ERB65TU2",
         "type": "article-newspaper",
@@ -1914,7 +1958,9 @@
         "Methodology",
         "Social aspects"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "IKQFRT6Z"
+      ],
       "csl": {
         "id": "747207/G47YSBSC",
         "type": "book",
@@ -2341,7 +2387,9 @@
       "date": "2019",
       "year": 2019,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/U3ZGQN99",
         "type": "book",
@@ -2422,7 +2470,10 @@
       "tags": [
         "uncertainty"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F",
+        "ZZJNKMSU"
+      ],
       "csl": {
         "id": "747207/TNIAXGRH",
         "type": "article-journal",
@@ -2527,13 +2578,15 @@
       "tags": [
         "mapping-systems"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "9DXPI4J7"
+      ],
       "csl": {
         "id": "747207/JTEGM2U3",
         "type": "chapter",
         "abstract": "Open access peer-reviewed chapter",
         "DOI": "10.5772/46129",
-        "ISBN": "9789535106890",
+        "ISBN": "978-953-51-0689-0",
         "language": "en",
         "note": "DOI: 10.5772/46129",
         "publisher": "IntechOpen",
@@ -2604,7 +2657,7 @@
         }
       },
       "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Garc&#xED;a, Ricardo, Juan Pablo de Castro, Elena Verd&#xFA;, et al. 2012. <i>Web Map Tile Services for Spatial Data Infrastructures: Management and Optimization</i>. IntechOpen. https://doi.org/10.5772/46129.</div>\n</div>",
-      "bibtex": "\n@incollection{garcia_web_2012,\n\ttitle = {Web {Map} {Tile} {Services} for {Spatial} {Data} {Infrastructures}: {Management} and {Optimization}},\n\tisbn = {9789535106890},\n\tshorttitle = {Web {Map} {Tile} {Services} for {Spatial} {Data} {Infrastructures}},\n\turl = {https://www.intechopen.com/chapters/38302},\n\tdoi = {10.5772/46129},\n\tabstract = {Open access peer-reviewed chapter},\n\tlanguage = {en},\n\turldate = {2026-02-04},\n\tpublisher = {IntechOpen},\n\tauthor = {García, Ricardo and Castro, Juan Pablo de and Verdú, Elena and Verdú, María Jesús and Regueras, Luisa María and García, Ricardo and Castro, Juan Pablo de and Verdú, Elena and Verdú, María Jesús and Regueras, Luisa María},\n\tmonth = aug,\n\tyear = {2012},\n\tdoi = {10.5772/46129},\n\tkeywords = {mapping-systems},\n}\n"
+      "bibtex": "\n@incollection{garcia_web_2012,\n\ttitle = {Web {Map} {Tile} {Services} for {Spatial} {Data} {Infrastructures}: {Management} and {Optimization}},\n\tisbn = {978-953-51-0689-0},\n\tshorttitle = {Web {Map} {Tile} {Services} for {Spatial} {Data} {Infrastructures}},\n\turl = {https://www.intechopen.com/chapters/38302},\n\tdoi = {10.5772/46129},\n\tabstract = {Open access peer-reviewed chapter},\n\tlanguage = {en},\n\turldate = {2026-02-04},\n\tpublisher = {IntechOpen},\n\tauthor = {García, Ricardo and Castro, Juan Pablo de and Verdú, Elena and Verdú, María Jesús and Regueras, Luisa María and García, Ricardo and Castro, Juan Pablo de and Verdú, Elena and Verdú, María Jesús and Regueras, Luisa María},\n\tmonth = aug,\n\tyear = {2012},\n\tdoi = {10.5772/46129},\n\tkeywords = {mapping-systems},\n}\n"
     },
     {
       "key": "WNEAX6KF",
@@ -2671,7 +2724,9 @@
         "Theory",
         "computer"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/AMYZ33ZV",
         "type": "article-journal",
@@ -2825,7 +2880,10 @@
       "date": "2023",
       "year": 2023,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q",
+        "PGTZV2GX"
+      ],
       "csl": {
         "id": "747207/4SPT78AB",
         "type": "book",
@@ -3092,7 +3150,9 @@
         "Natural hazards",
         "Sustainability"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "E2HWAZRJ"
+      ],
       "csl": {
         "id": "747207/6VWVPVVM",
         "type": "article-journal",
@@ -3290,7 +3350,9 @@
       "date": "2025",
       "year": 2025,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "S3Z4ZXR8"
+      ],
       "csl": {
         "id": "747207/25FVMRF3",
         "type": "book",
@@ -3357,7 +3419,9 @@
       "date": "1978",
       "year": 1978,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/Z4WNISIG",
         "type": "article-journal",
@@ -3407,7 +3471,9 @@
       "date": "2023",
       "year": 2023,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/M77RDA79",
         "type": "article-journal",
@@ -3458,7 +3524,9 @@
       "tags": [
         "desire path"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/M4XAAABM",
         "type": "post-weblog",
@@ -3845,7 +3913,10 @@
       "date": "2020",
       "year": 2020,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F",
+        "IKQFRT6Z"
+      ],
       "csl": {
         "id": "747207/TT8D3XSS",
         "type": "article-journal",
@@ -4051,7 +4122,10 @@
         "Case studies",
         "Computer Science - Computer Vision and Pattern Recognition"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "9DXPI4J7",
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/ZPIPTXYX",
         "type": "webpage",
@@ -4131,8 +4205,13 @@
       "doi": "10.1177/23998083251387477",
       "date": "2025",
       "year": 2025,
-      "tags": [],
-      "subcollections": [],
+      "tags": [
+        "Climate change adaptation",
+        "climate adaptation"
+      ],
+      "subcollections": [
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/4E54L4ZH",
         "type": "article-journal",
@@ -4190,7 +4269,7 @@
         }
       },
       "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Liu, Cuiling, Xinyue Ye, Yangyang Xu, Quan Sun, and Yong Xu. 2025. &#x201C;Exploring the Impact of Urban Morphology on Heat Stress: A High-Resolution Microclimate Simulation Study.&#x201D; <i>Environment and Planning B: Urban Analytics and City Science</i>, October 15, 23998083251387477. https://doi.org/10.1177/23998083251387477.</div>\n</div>",
-      "bibtex": "\n@article{liu_exploring_2025,\n\ttitle = {Exploring the impact of urban morphology on heat stress: {A} high-resolution microclimate simulation study},\n\tissn = {2399-8083, 2399-8091},\n\tshorttitle = {Exploring the impact of urban morphology on heat stress},\n\turl = {https://journals.sagepub.com/doi/10.1177/23998083251387477},\n\tdoi = {10.1177/23998083251387477},\n\tabstract = {Extreme heat poses significant environmental and health risks. These risks often disproportionately affect marginalized and disenfranchised communities. Neighborhood-scale planning is essential for addressing climate change through adaptation strategies. Currently, there is a lack of long-term weather data at the neighborhood level, limiting the ability to analyze localized weather trends and compare variations across areas. This gap persists due to the challenges of collecting fine-scale local data, including significant time demands, limited resources, and potential privacy concerns. To bridge this gap, this project employs the Urban Weather Generator model to generate neighborhood-scale temperature and relative humidity data for the city of Houston. The neighborhood size is defined using a 500-by-500-m grid. Based on the comprehensive analysis of heat stress variation across these neighborhoods, we identify areas with notably higher or lower heat stress duration. This dataset is intended to inform targeted interventions in microclimate design and personal-level heat adaptation.},\n\tlanguage = {en},\n\turldate = {2026-01-19},\n\tjournal = {Environment and Planning B: Urban Analytics and City Science},\n\tauthor = {Liu, Cuiling and Ye, Xinyue and Xu, Yangyang and Sun, Quan and Xu, Yong},\n\tmonth = oct,\n\tyear = {2025},\n\tpages = {23998083251387477},\n}\n"
+      "bibtex": "\n@article{liu_exploring_2025,\n\ttitle = {Exploring the impact of urban morphology on heat stress: {A} high-resolution microclimate simulation study},\n\tissn = {2399-8083, 2399-8091},\n\tshorttitle = {Exploring the impact of urban morphology on heat stress},\n\turl = {https://journals.sagepub.com/doi/10.1177/23998083251387477},\n\tdoi = {10.1177/23998083251387477},\n\tabstract = {Extreme heat poses significant environmental and health risks. These risks often disproportionately affect marginalized and disenfranchised communities. Neighborhood-scale planning is essential for addressing climate change through adaptation strategies. Currently, there is a lack of long-term weather data at the neighborhood level, limiting the ability to analyze localized weather trends and compare variations across areas. This gap persists due to the challenges of collecting fine-scale local data, including significant time demands, limited resources, and potential privacy concerns. To bridge this gap, this project employs the Urban Weather Generator model to generate neighborhood-scale temperature and relative humidity data for the city of Houston. The neighborhood size is defined using a 500-by-500-m grid. Based on the comprehensive analysis of heat stress variation across these neighborhoods, we identify areas with notably higher or lower heat stress duration. This dataset is intended to inform targeted interventions in microclimate design and personal-level heat adaptation.},\n\tlanguage = {en},\n\turldate = {2026-01-19},\n\tjournal = {Environment and Planning B: Urban Analytics and City Science},\n\tauthor = {Liu, Cuiling and Ye, Xinyue and Xu, Yangyang and Sun, Quan and Xu, Yong},\n\tmonth = oct,\n\tyear = {2025},\n\tkeywords = {Climate change adaptation, climate adaptation},\n\tpages = {23998083251387477},\n}\n"
     },
     {
       "key": "SYN8H39L",
@@ -4354,41 +4433,6 @@
       "bibtex": "\n@book{lynch_image_1960,\n\taddress = {Cambridge, Massachusetts ; London, England},\n\ttitle = {The image of the city},\n\tisbn = {978-0-262-12004-3 978-0-262-62001-7},\n\tpublisher = {The MIT Press, Massachusetts Institute of Technology},\n\tauthor = {Lynch, Kevin},\n\tyear = {1960},\n\tkeywords = {City planning, United States},\n}\n"
     },
     {
-      "key": "NBX5VLHA",
-      "type": "chapter",
-      "title": "Ch 9: Methods of Spatial Data Analysis",
-      "date": "2006",
-      "year": 2006,
-      "tags": [],
-      "subcollections": [],
-      "csl": {
-        "id": "747207/NBX5VLHA",
-        "type": "chapter",
-        "container-title": "GIS for the Urban Environment",
-        "note": "required",
-        "title": "Ch 9: Methods of Spatial Data Analysis",
-        "author": [
-          {
-            "family": "Maantay",
-            "given": "Juliana"
-          },
-          {
-            "family": "Ziegler",
-            "given": "John"
-          }
-        ],
-        "issued": {
-          "date-parts": [
-            [
-              2006
-            ]
-          ]
-        }
-      },
-      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Maantay, Juliana, and John Ziegler. 2006. &#x201C;Ch 9: Methods of Spatial Data Analysis.&#x201D; In <i>GIS for the Urban Environment</i>.</div>\n</div>",
-      "bibtex": "\n@incollection{maantay_ch_2006,\n\ttitle = {Ch 9: {Methods} of {Spatial} {Data} {Analysis}},\n\tbooktitle = {{GIS} for the {Urban} {Environment}},\n\tauthor = {Maantay, Juliana and Ziegler, John},\n\tyear = {2006},\n\tnote = {required},\n}\n"
-    },
-    {
       "key": "RGHPZ9QM",
       "type": "chapter",
       "title": "Thematic Mapping",
@@ -4460,6 +4504,43 @@
       "bibtex": "\n@incollection{maantay_spatial_2006,\n\ttitle = {Spatial {Data} and {Basic} {Mapping} {Concepts}},\n\tbooktitle = {{GIS} for the {Urban} {Environment}},\n\tauthor = {Maantay, Juliana and Ziegler, John},\n\tyear = {2006},\n\tnote = {required},\n}\n"
     },
     {
+      "key": "NBX5VLHA",
+      "type": "chapter",
+      "title": "Ch 9: Methods of Spatial Data Analysis",
+      "date": "2006",
+      "year": 2006,
+      "tags": [],
+      "subcollections": [
+        "ERJ92FM8"
+      ],
+      "csl": {
+        "id": "747207/NBX5VLHA",
+        "type": "chapter",
+        "container-title": "GIS for the Urban Environment",
+        "note": "required",
+        "title": "Ch 9: Methods of Spatial Data Analysis",
+        "author": [
+          {
+            "family": "Maantay",
+            "given": "Juliana"
+          },
+          {
+            "family": "Ziegler",
+            "given": "John"
+          }
+        ],
+        "issued": {
+          "date-parts": [
+            [
+              2006
+            ]
+          ]
+        }
+      },
+      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Maantay, Juliana, and John Ziegler. 2006. &#x201C;Ch 9: Methods of Spatial Data Analysis.&#x201D; In <i>GIS for the Urban Environment</i>.</div>\n</div>",
+      "bibtex": "\n@incollection{maantay_ch_2006,\n\ttitle = {Ch 9: {Methods} of {Spatial} {Data} {Analysis}},\n\tbooktitle = {{GIS} for the {Urban} {Environment}},\n\tauthor = {Maantay, Juliana and Ziegler, John},\n\tyear = {2006},\n\tnote = {required},\n}\n"
+    },
+    {
       "key": "TN7986PG",
       "type": "webpage",
       "title": "Graph layout",
@@ -4471,7 +4552,10 @@
         "Theory",
         "network analysis"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF",
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/TN7986PG",
         "type": "webpage",
@@ -4564,7 +4648,9 @@
       "title": "A New World Map on an Irregular Heptahedron",
       "date": "2006",
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "XNQNE959"
+      ],
       "csl": {
         "id": "747207/Y2KRXDB9",
         "type": "thesis",
@@ -4686,7 +4772,10 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F",
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/YU35IK7K",
         "type": "post-weblog",
@@ -4876,7 +4965,10 @@
       "date": "2020",
       "year": 2020,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "E2HWAZRJ",
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/YP6J6EAB",
         "type": "article-journal",
@@ -5129,7 +5221,10 @@
       "tags": [
         "Community development-Michigan-Detroit."
       ],
-      "subcollections": [],
+      "subcollections": [
+        "IKQFRT6Z",
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/5Y46HPVQ",
         "type": "book",
@@ -5613,7 +5708,10 @@
         "Sociocultural Anthropology",
         "Volunteered geographic information"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "E2HWAZRJ",
+        "IKQFRT6Z"
+      ],
       "csl": {
         "id": "747207/RP4W4YBJ",
         "type": "article-journal",
@@ -5868,7 +5966,9 @@
         "Theory",
         "macroscope"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/RDQ7QWE2",
         "type": "article-journal",
@@ -5956,7 +6056,9 @@
         "Science / Earth Sciences / Geology",
         "Travel / Maps & Road Atlases"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "XNQNE959"
+      ],
       "csl": {
         "id": "747207/ID639BIQ",
         "type": "book",
@@ -5993,7 +6095,10 @@
       "title": "West Philadelphia Landscape Project",
       "url": "https://wplp.net/about/",
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "IKQFRT6Z",
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/I4MGDNUJ",
         "type": "webpage",
@@ -6134,7 +6239,9 @@
       "date": "1970",
       "year": 1970,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F"
+      ],
       "csl": {
         "id": "747207/S5NGFGAN",
         "type": "article-journal",
@@ -6277,7 +6384,10 @@
         "Restaurants",
         "Technology"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q",
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/KNPRXU2I",
         "type": "article-newspaper",
@@ -6345,7 +6455,9 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "AGAC9I88"
+      ],
       "csl": {
         "id": "747207/9GIUHJ6Q",
         "type": "post-weblog",
@@ -6689,7 +6801,9 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "UP4V2S7X"
+      ],
       "csl": {
         "id": "747207/DAJ9YFCW",
         "type": "article-journal",
@@ -6859,7 +6973,11 @@
       "date": "2015",
       "year": 2015,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF",
+        "IKQFRT6Z",
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/MU57N7TL",
         "type": "paper-conference",
@@ -7000,7 +7118,9 @@
       "date": "1993",
       "year": 1993,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q"
+      ],
       "csl": {
         "id": "747207/V998M9H4",
         "type": "article-journal",
@@ -7037,7 +7157,10 @@
         "Cartography",
         "Perception"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F",
+        "PGTZV2GX"
+      ],
       "csl": {
         "id": "747207/36Y8EEPD",
         "type": "article-journal",
@@ -7142,88 +7265,6 @@
       "bibtex": "\n@article{xin_impact_2022,\n\ttitle = {Impact of the {COVID}-19 pandemic on urban human mobility - {A} multiscale geospatial network analysis using {New} {York} bike-sharing data},\n\tvolume = {126},\n\tissn = {02642751},\n\turl = {https://linkinghub.elsevier.com/retrieve/pii/S0264275122001160},\n\tdoi = {10.1016/j.cities.2022.103677},\n\tlanguage = {en},\n\turldate = {2024-06-03},\n\tjournal = {Cities},\n\tauthor = {Xin, Rui and Ai, Tinghua and Ding, Linfang and Zhu, Ruoxin and Meng, Liqiu},\n\tmonth = jul,\n\tyear = {2022},\n\tpages = {103677},\n}\n"
     },
     {
-      "key": "ZNQFDKKP",
-      "type": "article-journal",
-      "title": "Geodesign in the era of artificial intelligence",
-      "url": "https://doi.org/10.1007/s44243-025-00054-5",
-      "doi": "10.1007/s44243-025-00054-5",
-      "date": "2025",
-      "year": 2025,
-      "tags": [
-        "Artificial Intelligence",
-        "Ethics",
-        "Geodesign",
-        "Spatial planning"
-      ],
-      "subcollections": [],
-      "csl": {
-        "id": "747207/ZNQFDKKP",
-        "type": "article-journal",
-        "abstract": "This paper explores the evolution of Geodesign in addressing spatial and environmental challenges from its early foundations to the recent integration of artificial intelligence (AI). AI enhances existing Geodesign methods by automating spatial data analysis, improving land use classification, refining heat island effect assessment, optimizing energy use, facilitating green infrastructure planning, and generating design scenarios. Despite the transformative potential of AI in Geodesign, challenges related to data quality, model interpretability, and ethical concerns such as privacy and bias persist. This paper highlights case studies that demonstrate the application of AI in Geodesign, offering insights into its role in understanding existing systems and designing future changes. The paper concludes by advocating for the responsible and transparent integration of AI to ensure equitable and effective Geodesign outcomes.",
-        "container-title": "Frontiers of Urban and Rural Planning",
-        "DOI": "10.1007/s44243-025-00054-5",
-        "ISSN": "2731-6661",
-        "issue": "1",
-        "journalAbbreviation": "Front. Urban Rural Plan.",
-        "language": "en",
-        "page": "4",
-        "source": "Springer Link",
-        "title": "Geodesign in the era of artificial intelligence",
-        "URL": "https://doi.org/10.1007/s44243-025-00054-5",
-        "volume": "3",
-        "author": [
-          {
-            "family": "Ye",
-            "given": "Xinyue"
-          },
-          {
-            "family": "Huang",
-            "given": "Tianchen"
-          },
-          {
-            "family": "Song",
-            "given": "Yang"
-          },
-          {
-            "family": "Li",
-            "given": "Xin"
-          },
-          {
-            "family": "Newman",
-            "given": "Galen"
-          },
-          {
-            "family": "Lin",
-            "given": "Zhongjie"
-          },
-          {
-            "family": "Wu",
-            "given": "Dayong Jason"
-          }
-        ],
-        "accessed": {
-          "date-parts": [
-            [
-              2026,
-              1,
-              26
-            ]
-          ]
-        },
-        "issued": {
-          "date-parts": [
-            [
-              2025,
-              3,
-              7
-            ]
-          ]
-        }
-      },
-      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Ye, Xinyue, Tianchen Huang, Yang Song, et al. 2025. &#x201C;Geodesign in the Era of Artificial Intelligence.&#x201D; <i>Frontiers of Urban and Rural Planning</i> 3 (1): 4. https://doi.org/10.1007/s44243-025-00054-5.</div>\n</div>",
-      "bibtex": "\n@article{ye_geodesign_2025,\n\ttitle = {Geodesign in the era of artificial intelligence},\n\tvolume = {3},\n\tissn = {2731-6661},\n\turl = {https://doi.org/10.1007/s44243-025-00054-5},\n\tdoi = {10.1007/s44243-025-00054-5},\n\tabstract = {This paper explores the evolution of Geodesign in addressing spatial and environmental challenges from its early foundations to the recent integration of artificial intelligence (AI). AI enhances existing Geodesign methods by automating spatial data analysis, improving land use classification, refining heat island effect assessment, optimizing energy use, facilitating green infrastructure planning, and generating design scenarios. Despite the transformative potential of AI in Geodesign, challenges related to data quality, model interpretability, and ethical concerns such as privacy and bias persist. This paper highlights case studies that demonstrate the application of AI in Geodesign, offering insights into its role in understanding existing systems and designing future changes. The paper concludes by advocating for the responsible and transparent integration of AI to ensure equitable and effective Geodesign outcomes.},\n\tlanguage = {en},\n\tnumber = {1},\n\turldate = {2026-01-26},\n\tjournal = {Frontiers of Urban and Rural Planning},\n\tauthor = {Ye, Xinyue and Huang, Tianchen and Song, Yang and Li, Xin and Newman, Galen and Lin, Zhongjie and Wu, Dayong Jason},\n\tmonth = mar,\n\tyear = {2025},\n\tkeywords = {Artificial Intelligence, Ethics, Geodesign, Spatial planning},\n\tpages = {4},\n}\n"
-    },
-    {
       "key": "IDVCI7LC",
       "type": "article-journal",
       "title": "Geodesign in the era of artificial intelligence",
@@ -7237,7 +7278,9 @@
         "Geodesign",
         "Spatial planning"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "UP4V2S7X"
+      ],
       "csl": {
         "id": "747207/IDVCI7LC",
         "type": "article-journal",
@@ -7306,6 +7349,91 @@
       "bibtex": "\n@article{ye_geodesign_2025,\n\ttitle = {Geodesign in the era of artificial intelligence},\n\tvolume = {3},\n\tissn = {2731-6661},\n\turl = {https://doi.org/10.1007/s44243-025-00054-5},\n\tdoi = {10.1007/s44243-025-00054-5},\n\tabstract = {This paper explores the evolution of Geodesign in addressing spatial and environmental challenges from its early foundations to the recent integration of artificial intelligence (AI). AI enhances existing Geodesign methods by automating spatial data analysis, improving land use classification, refining heat island effect assessment, optimizing energy use, facilitating green infrastructure planning, and generating design scenarios. Despite the transformative potential of AI in Geodesign, challenges related to data quality, model interpretability, and ethical concerns such as privacy and bias persist. This paper highlights case studies that demonstrate the application of AI in Geodesign, offering insights into its role in understanding existing systems and designing future changes. The paper concludes by advocating for the responsible and transparent integration of AI to ensure equitable and effective Geodesign outcomes.},\n\tlanguage = {en},\n\tnumber = {1},\n\turldate = {2026-03-13},\n\tjournal = {Frontiers of Urban and Rural Planning},\n\tauthor = {Ye, Xinyue and Huang, Tianchen and Song, Yang and Li, Xin and Newman, Galen and Lin, Zhongjie and Wu, Dayong Jason},\n\tmonth = mar,\n\tyear = {2025},\n\tkeywords = {Artificial Intelligence, Ethics, Geodesign, Spatial planning},\n\tpages = {4},\n}\n"
     },
     {
+      "key": "ZNQFDKKP",
+      "type": "article-journal",
+      "title": "Geodesign in the era of artificial intelligence",
+      "url": "https://doi.org/10.1007/s44243-025-00054-5",
+      "doi": "10.1007/s44243-025-00054-5",
+      "date": "2025",
+      "year": 2025,
+      "tags": [
+        "Artificial Intelligence",
+        "Ethics",
+        "Geodesign",
+        "Spatial planning"
+      ],
+      "subcollections": [
+        "S3Z4ZXR8",
+        "UP4V2S7X"
+      ],
+      "csl": {
+        "id": "747207/ZNQFDKKP",
+        "type": "article-journal",
+        "abstract": "This paper explores the evolution of Geodesign in addressing spatial and environmental challenges from its early foundations to the recent integration of artificial intelligence (AI). AI enhances existing Geodesign methods by automating spatial data analysis, improving land use classification, refining heat island effect assessment, optimizing energy use, facilitating green infrastructure planning, and generating design scenarios. Despite the transformative potential of AI in Geodesign, challenges related to data quality, model interpretability, and ethical concerns such as privacy and bias persist. This paper highlights case studies that demonstrate the application of AI in Geodesign, offering insights into its role in understanding existing systems and designing future changes. The paper concludes by advocating for the responsible and transparent integration of AI to ensure equitable and effective Geodesign outcomes.",
+        "container-title": "Frontiers of Urban and Rural Planning",
+        "DOI": "10.1007/s44243-025-00054-5",
+        "ISSN": "2731-6661",
+        "issue": "1",
+        "journalAbbreviation": "Front. Urban Rural Plan.",
+        "language": "en",
+        "page": "4",
+        "source": "Springer Link",
+        "title": "Geodesign in the era of artificial intelligence",
+        "URL": "https://doi.org/10.1007/s44243-025-00054-5",
+        "volume": "3",
+        "author": [
+          {
+            "family": "Ye",
+            "given": "Xinyue"
+          },
+          {
+            "family": "Huang",
+            "given": "Tianchen"
+          },
+          {
+            "family": "Song",
+            "given": "Yang"
+          },
+          {
+            "family": "Li",
+            "given": "Xin"
+          },
+          {
+            "family": "Newman",
+            "given": "Galen"
+          },
+          {
+            "family": "Lin",
+            "given": "Zhongjie"
+          },
+          {
+            "family": "Wu",
+            "given": "Dayong Jason"
+          }
+        ],
+        "accessed": {
+          "date-parts": [
+            [
+              2026,
+              1,
+              26
+            ]
+          ]
+        },
+        "issued": {
+          "date-parts": [
+            [
+              2025,
+              3,
+              7
+            ]
+          ]
+        }
+      },
+      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Ye, Xinyue, Tianchen Huang, Yang Song, et al. 2025. &#x201C;Geodesign in the Era of Artificial Intelligence.&#x201D; <i>Frontiers of Urban and Rural Planning</i> 3 (1): 4. https://doi.org/10.1007/s44243-025-00054-5.</div>\n</div>",
+      "bibtex": "\n@article{ye_geodesign_2025,\n\ttitle = {Geodesign in the era of artificial intelligence},\n\tvolume = {3},\n\tissn = {2731-6661},\n\turl = {https://doi.org/10.1007/s44243-025-00054-5},\n\tdoi = {10.1007/s44243-025-00054-5},\n\tabstract = {This paper explores the evolution of Geodesign in addressing spatial and environmental challenges from its early foundations to the recent integration of artificial intelligence (AI). AI enhances existing Geodesign methods by automating spatial data analysis, improving land use classification, refining heat island effect assessment, optimizing energy use, facilitating green infrastructure planning, and generating design scenarios. Despite the transformative potential of AI in Geodesign, challenges related to data quality, model interpretability, and ethical concerns such as privacy and bias persist. This paper highlights case studies that demonstrate the application of AI in Geodesign, offering insights into its role in understanding existing systems and designing future changes. The paper concludes by advocating for the responsible and transparent integration of AI to ensure equitable and effective Geodesign outcomes.},\n\tlanguage = {en},\n\tnumber = {1},\n\turldate = {2026-01-26},\n\tjournal = {Frontiers of Urban and Rural Planning},\n\tauthor = {Ye, Xinyue and Huang, Tianchen and Song, Yang and Li, Xin and Newman, Galen and Lin, Zhongjie and Wu, Dayong Jason},\n\tmonth = mar,\n\tyear = {2025},\n\tkeywords = {Artificial Intelligence, Ethics, Geodesign, Spatial planning},\n\tpages = {4},\n}\n"
+    },
+    {
       "key": "F4GFAPKB",
       "type": "chapter",
       "title": "Urban Planning and GIS",
@@ -7347,7 +7475,9 @@
         "Computer Science - Data Structures and Algorithms",
         "Data format"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "9DXPI4J7"
+      ],
       "csl": {
         "id": "747207/IE5M4HWQ",
         "type": "webpage",
@@ -7406,7 +7536,10 @@
         "Computer Science - Computer Vision and Pattern Recognition",
         "Computer Science - Computers and Society"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "T3AL7PGA",
+        "UP4V2S7X"
+      ],
       "csl": {
         "id": "747207/J5NV6SH4",
         "type": "article",
@@ -7490,7 +7623,9 @@
       "tags": [
         "Dataset"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "9DXPI4J7"
+      ],
       "csl": {
         "id": "747207/E3CXIG4C",
         "type": "article-journal",
@@ -7559,7 +7694,9 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/2G5EL4DS",
         "type": "webpage",
@@ -7589,6 +7726,46 @@
       "bibtex": "\n@misc{noauthor_geography_2026,\n\ttitle = {A geography of an {American} citizenship},\n\turl = {https://libraryoflostmaps.com/2026/04/01/a-geography-of-an-american-citizenship/},\n\tabstract = {Explore Richard Edes Harrison's impactful 1952 map, 'The U.S Commitment,' revealing America's post-war geopolitical landscape.},\n\turldate = {2026-04-03},\n\tmonth = apr,\n\tyear = {2026},\n}\n"
     },
     {
+      "key": "NPZQ324A",
+      "type": "webpage",
+      "title": "Mapping Destruction—A Conversation with Jamon Van Den Hoek of Conflict Ecology",
+      "url": "https://www.merip.org/2026/02/mapping-destruction-a-conversation-with-jamon-van-den-hoek-of-conflict-ecology/",
+      "date": "2026",
+      "year": 2026,
+      "tags": [],
+      "subcollections": [
+        "T3AL7PGA",
+        "UXN7JR59"
+      ],
+      "csl": {
+        "id": "747207/NPZQ324A",
+        "type": "webpage",
+        "abstract": "Changing scales of conflict and advances in satellite imagery are reshaping how damage is assessed.",
+        "title": "Mapping Destruction—A Conversation with Jamon Van Den Hoek of Conflict Ecology",
+        "URL": "https://www.merip.org/2026/02/mapping-destruction-a-conversation-with-jamon-van-den-hoek-of-conflict-ecology/",
+        "accessed": {
+          "date-parts": [
+            [
+              2026,
+              3,
+              1
+            ]
+          ]
+        },
+        "issued": {
+          "date-parts": [
+            [
+              2026,
+              2,
+              11
+            ]
+          ]
+        }
+      },
+      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">&#x201C;Mapping Destruction&#x2014;A Conversation with Jamon Van Den Hoek of Conflict Ecology.&#x201D; 2026. February 11. https://www.merip.org/2026/02/mapping-destruction-a-conversation-with-jamon-van-den-hoek-of-conflict-ecology/.</div>\n</div>",
+      "bibtex": "\n@misc{noauthor_mapping_2026,\n\ttitle = {Mapping {Destruction}—{A} {Conversation} with {Jamon} {Van} {Den} {Hoek} of {Conflict} {Ecology}},\n\turl = {https://www.merip.org/2026/02/mapping-destruction-a-conversation-with-jamon-van-den-hoek-of-conflict-ecology/},\n\tabstract = {Changing scales of conflict and advances in satellite imagery are reshaping how damage is assessed.},\n\turldate = {2026-03-01},\n\tmonth = feb,\n\tyear = {2026},\n}\n"
+    },
+    {
       "key": "ERGXRL6C",
       "type": "webpage",
       "title": "How Lemontree improved map performance with a small refactor",
@@ -7596,7 +7773,9 @@
       "date": "2026",
       "year": 2026,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "9DXPI4J7"
+      ],
       "csl": {
         "id": "747207/ERGXRL6C",
         "type": "webpage",
@@ -7633,7 +7812,9 @@
       "date": "2023",
       "year": 2023,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "UP4V2S7X"
+      ],
       "csl": {
         "id": "747207/QJ3M53BD",
         "type": "post-weblog",
@@ -7662,43 +7843,6 @@
       "bibtex": "\n@misc{noauthor_urban_2023,\n\ttitle = {{URBAN} {AI} {GUIDE}},\n\turl = {https://urbanai.fr/our-works/urban-ai-guide/},\n\turldate = {2026-02-13},\n\tmonth = feb,\n\tyear = {2023},\n}\n"
     },
     {
-      "key": "NPZQ324A",
-      "type": "webpage",
-      "title": "Mapping Destruction—A Conversation with Jamon Van Den Hoek of Conflict Ecology",
-      "url": "https://www.merip.org/2026/02/mapping-destruction-a-conversation-with-jamon-van-den-hoek-of-conflict-ecology/",
-      "date": "2026",
-      "year": 2026,
-      "tags": [],
-      "subcollections": [],
-      "csl": {
-        "id": "747207/NPZQ324A",
-        "type": "webpage",
-        "abstract": "Changing scales of conflict and advances in satellite imagery are reshaping how damage is assessed.",
-        "title": "Mapping Destruction—A Conversation with Jamon Van Den Hoek of Conflict Ecology",
-        "URL": "https://www.merip.org/2026/02/mapping-destruction-a-conversation-with-jamon-van-den-hoek-of-conflict-ecology/",
-        "accessed": {
-          "date-parts": [
-            [
-              2026,
-              3,
-              1
-            ]
-          ]
-        },
-        "issued": {
-          "date-parts": [
-            [
-              2026,
-              2,
-              11
-            ]
-          ]
-        }
-      },
-      "bib": "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">&#x201C;Mapping Destruction&#x2014;A Conversation with Jamon Van Den Hoek of Conflict Ecology.&#x201D; 2026. February 11. https://www.merip.org/2026/02/mapping-destruction-a-conversation-with-jamon-van-den-hoek-of-conflict-ecology/.</div>\n</div>",
-      "bibtex": "\n@misc{noauthor_mapping_2026,\n\ttitle = {Mapping {Destruction}—{A} {Conversation} with {Jamon} {Van} {Den} {Hoek} of {Conflict} {Ecology}},\n\turl = {https://www.merip.org/2026/02/mapping-destruction-a-conversation-with-jamon-van-den-hoek-of-conflict-ecology/},\n\tabstract = {Changing scales of conflict and advances in satellite imagery are reshaping how damage is assessed.},\n\turldate = {2026-03-01},\n\tmonth = feb,\n\tyear = {2026},\n}\n"
-    },
-    {
       "key": "GJIDKZL5",
       "type": "document",
       "title": "Resisting Data Colonialism",
@@ -7710,7 +7854,10 @@
         "Data extractivism",
         "Theory"
       ],
-      "subcollections": [],
+      "subcollections": [
+        "G32ZL73Q",
+        "IKQFRT6Z"
+      ],
       "csl": {
         "id": "747207/GJIDKZL5",
         "type": "document",
@@ -7735,7 +7882,9 @@
       "date": "2009",
       "year": 2009,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "T3AL7PGA"
+      ],
       "csl": {
         "id": "747207/BTHJG429",
         "type": "webpage",
@@ -7774,7 +7923,10 @@
       "date": "2009",
       "year": 2009,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "DRE4ZF6F",
+        "E2HWAZRJ"
+      ],
       "csl": {
         "id": "747207/S2RZF8FL",
         "type": "webpage",
@@ -7808,7 +7960,9 @@
       "date": "2015",
       "year": 2015,
       "tags": [],
-      "subcollections": [],
+      "subcollections": [
+        "6SPRPNXF"
+      ],
       "csl": {
         "id": "747207/24U9NDJN",
         "type": "post-weblog",

--- a/src/pages/bibliography.astro
+++ b/src/pages/bibliography.astro
@@ -62,7 +62,7 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
 <BaseLayout title="Bibliography">
   <h1 class="text-5xl font-semibold tracking-tight mb-3 text-text">Bibliography</h1>
   <p class="text-lg text-muted mb-8 max-w-2xl">
-    Course readings and references, formatted in Chicago Author-Date style.
+    Course readings and references.
     Synced from a
     <a class="text-link hover:text-link-hover underline-offset-2" href="https://www.zotero.org" target="_blank" rel="noreferrer noopener">Zotero</a>
     collection and refreshed periodically.

--- a/src/pages/bibliography.astro
+++ b/src/pages/bibliography.astro
@@ -104,25 +104,55 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
       </div>
 
       {renderedSections.length > 1 && (
-        <nav
-          aria-label="Jump to section"
-          class="mb-10 -mx-1 flex flex-wrap gap-1.5 text-sm"
-          data-section-jump
+        <div
+          class="sticky top-16 z-30 -mx-4 sm:-mx-6 mb-10 bg-bg/95 backdrop-blur border-b border-border"
         >
-          {renderedSections.map((section) => (
-            <a
-              href={`#section-${section.key}`}
-              data-jump-key={section.key}
-              class="inline-flex items-baseline gap-1.5 px-2.5 py-1 rounded-full border border-border text-text no-underline hover:border-accent hover:text-accent transition-colors"
-            >
-              <span>{section.name}</span>
-              <span class="text-xs text-subtle tabular-nums" data-jump-count>
-                {bySection[section.key].length}
-              </span>
-            </a>
-          ))}
-        </nav>
+          <nav
+            aria-label="Jump to section"
+            class="max-w-full mx-auto px-4 sm:px-6 py-3 flex flex-wrap gap-1.5 text-sm"
+            data-section-jump
+          >
+            {renderedSections.map((section) => (
+              <a
+                href={`#section-${section.key}`}
+                data-jump-key={section.key}
+                class="inline-flex items-baseline gap-1.5 px-2.5 py-1 rounded-full border border-border text-text no-underline hover:border-accent hover:text-accent transition-colors"
+              >
+                <span>{section.name}</span>
+                <span class="text-xs text-subtle tabular-nums" data-jump-count>
+                  {bySection[section.key].length}
+                </span>
+              </a>
+            ))}
+          </nav>
+        </div>
       )}
+
+      {/* Floating scroll-to-top button, shown after the user scrolls past
+          a viewport-and-a-bit. Positioned at the bottom-right and
+          accessible via keyboard. */}
+      <button
+        type="button"
+        data-back-to-top
+        aria-label="Back to top"
+        class="fixed bottom-6 right-6 z-40 hidden h-10 w-10 items-center justify-center rounded-full border border-border bg-bg text-text shadow-sm hover:border-accent hover:text-accent transition-colors"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="12" y1="19" x2="12" y2="5" />
+          <polyline points="5 12 12 5 19 12" />
+        </svg>
+      </button>
 
       <div class="space-y-12" data-bibliography>
         {renderedSections.map((section) => (
@@ -379,6 +409,31 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
     window.addEventListener('hashchange', applyFilter);
 
     applyFilter();
+    attachBackToTop();
+  }
+
+  function attachBackToTop() {
+    const btn = document.querySelector<HTMLButtonElement>('[data-back-to-top]');
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+
+    // Show once the user has scrolled past one viewport. Uses the existing
+    // scroll listener pattern; rAF-throttled to avoid layout thrash.
+    let ticking = false;
+    const update = () => {
+      const past = window.scrollY > window.innerHeight;
+      btn.classList.toggle('hidden', !past);
+      btn.classList.toggle('flex', past);
+      ticking = false;
+    };
+    window.addEventListener('scroll', () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(update);
+    }, { passive: true });
+    update();
   }
 
   document.addEventListener('astro:page-load', attach);

--- a/src/pages/bibliography.astro
+++ b/src/pages/bibliography.astro
@@ -1,38 +1,63 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
+import zoteroData from '../data/zotero.json';
 
 const entries = await getCollection('bibliography');
 
-// Group by year (descending), unknown year goes to "Undated"
-const byYear: Record<string, typeof entries> = {};
-for (const e of entries) {
-  const year = e.data.year ? String(e.data.year) : 'Undated';
-  if (!byYear[year]) byYear[year] = [];
-  byYear[year].push(e);
-}
-const years = Object.keys(byYear).sort((a, b) => {
-  if (a === 'Undated') return 1;
-  if (b === 'Undated') return -1;
-  return Number(b) - Number(a);
-});
-
-// Within each year, sort alphabetically by the rendered citation (which
-// leads with author surname in Chicago style).
-for (const year of years) {
-  byYear[year].sort((a, b) =>
-    (a.data.bib || a.data.title).localeCompare(b.data.bib || b.data.title)
-  );
+interface SubCollectionMeta {
+  key: string;
+  name: string;
 }
 
-// Collect unique tags across the whole bibliography for the filter row.
-const tagCounts = new Map<string, number>();
-for (const e of entries) {
-  for (const tag of e.data.tags ?? []) {
-    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+// Pull the sub-collection metadata directly from the JSON (the content
+// collection only models entries, not the parent metadata).
+const subcollections: SubCollectionMeta[] = zoteroData.subcollections ?? [];
+
+// Group entries by sub-collection key. Items in multiple sub-collections
+// appear in each. Items in none go into "Uncategorized".
+type SectionEntry = (typeof entries)[number];
+const bySection: Record<string, SectionEntry[]> = {};
+const UNCATEGORIZED = '__uncategorized__';
+
+for (const entry of entries) {
+  const subs = entry.data.subcollections ?? [];
+  if (subs.length === 0) {
+    (bySection[UNCATEGORIZED] ??= []).push(entry);
+  } else {
+    for (const key of subs) {
+      (bySection[key] ??= []).push(entry);
+    }
   }
 }
-const allTags = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+
+// Sort within each section: by year desc, then alphabetically by rendered citation.
+for (const key of Object.keys(bySection)) {
+  bySection[key].sort((a, b) => {
+    const ya = a.data.year ?? -Infinity;
+    const yb = b.data.year ?? -Infinity;
+    if (yb !== ya) return yb - ya;
+    return (a.data.bib || a.data.title).localeCompare(b.data.bib || b.data.title);
+  });
+}
+
+// Render order: only sections that have entries. Sub-collections in their
+// configured order (alphabetical from the script), then Uncategorized last.
+const renderedSections: { key: string; name: string }[] = [];
+for (const sub of subcollections) {
+  if (bySection[sub.key]?.length) {
+    renderedSections.push({ key: sub.key, name: sub.name });
+  }
+}
+if (bySection[UNCATEGORIZED]?.length) {
+  renderedSections.push({
+    key: UNCATEGORIZED,
+    name: subcollections.length > 0 ? 'Uncategorized' : 'All references',
+  });
+}
+
+// Total tag count for the placeholder text in the search input.
+const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
 ---
 <BaseLayout title="Bibliography">
   <h1 class="text-5xl font-semibold tracking-tight mb-3 text-text">Bibliography</h1>
@@ -55,54 +80,63 @@ const allTags = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0])
     </div>
   ) : (
     <>
-      {allTags.length > 0 && (
-        <div
-          data-tag-filter
-          class="mb-12 -mx-1 flex flex-wrap items-center gap-1.5 text-sm"
-          aria-label="Filter by tag"
-        >
-          <span class="px-2 text-xs uppercase tracking-wider text-subtle">
-            Filter:
-          </span>
-          {allTags.map(([tag, count]) => (
-            <button
-              type="button"
-              data-tag={tag}
-              class="tag-chip inline-flex items-baseline gap-1.5 px-2.5 py-1 rounded-full border border-border text-text hover:border-accent hover:text-accent transition-colors"
-            >
-              <span>{tag}</span>
-              <span class="text-xs text-subtle tabular-nums">{count}</span>
-            </button>
-          ))}
+      {/* Search + filter row. The input filters entries by title/author/tag
+          (free-text). Active tag filters appear as removable chips below. */}
+      <div data-bib-filter class="mb-10 space-y-3">
+        <div class="flex items-center gap-3">
+          <label class="sr-only" for="bib-search">Search bibliography</label>
+          <input
+            id="bib-search"
+            type="search"
+            data-bib-search
+            placeholder={`Search title, author, or one of ${allTagCount} tags…`}
+            class="flex-1 px-4 py-2 rounded-lg border border-border bg-bg text-text placeholder:text-subtle focus:outline-none focus:border-accent transition-colors"
+          />
           <button
             type="button"
-            data-tag-clear
-            class="ml-2 px-2.5 py-1 text-xs text-subtle hover:text-text underline-offset-2 hover:underline hidden"
+            data-bib-clear
+            class="hidden px-3 py-2 text-sm text-subtle hover:text-text underline-offset-2 hover:underline"
           >
             Clear
           </button>
         </div>
-      )}
+        <div data-bib-active-tags class="flex flex-wrap gap-1.5 empty:hidden"></div>
+      </div>
 
       <div class="space-y-12" data-bibliography>
-        {years.map((year) => (
-          <section data-year-section data-year-tags={JSON.stringify(byYear[year].flatMap((e) => e.data.tags ?? []))}>
+        {renderedSections.map((section) => (
+          <section data-section data-section-key={section.key}>
             <h2 class="text-xs font-semibold text-accent uppercase tracking-[0.14em] mb-5">
-              {year}
+              <span>{section.name}</span>
+              <span class="ml-2 text-subtle font-normal" data-section-count>
+                ({bySection[section.key].length})
+              </span>
             </h2>
             <ul class="space-y-5">
-              {byYear[year].map((entry) => (
+              {bySection[section.key].map((entry) => (
                 <li
                   class="border-b border-border pb-5 last:border-b-0"
                   data-entry
                   data-entry-tags={JSON.stringify(entry.data.tags ?? [])}
+                  data-entry-text={[
+                    entry.data.title,
+                    entry.data.bib?.replace(/<[^>]+>/g, ' ') ?? '',
+                    (entry.data.tags ?? []).join(' '),
+                  ].join(' ').toLowerCase()}
                 >
                   <div class="bibliography-entry text-text leading-relaxed" set:html={entry.data.bib || `<em>${entry.data.title}</em>`} />
                   {entry.data.tags && entry.data.tags.length > 0 && (
                     <ul class="mt-2 flex flex-wrap gap-1.5 text-xs">
                       {entry.data.tags.map((tag) => (
-                        <li class="px-2 py-0.5 rounded-full bg-surface-strong text-muted">
-                          {tag}
+                        <li>
+                          <button
+                            type="button"
+                            data-tag-add={tag}
+                            class="px-2 py-0.5 rounded-full bg-surface-strong text-muted hover:bg-accent-soft hover:text-accent transition-colors cursor-pointer"
+                            title={`Filter by ${tag}`}
+                          >
+                            {tag}
+                          </button>
                         </li>
                       ))}
                     </ul>
@@ -137,7 +171,7 @@ const allTags = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0])
           </section>
         ))}
         <p data-empty-msg class="text-muted italic hidden">
-          No entries match the selected tags.
+          No entries match your filter.
         </p>
       </div>
     </>
@@ -145,117 +179,162 @@ const allTags = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0])
 </BaseLayout>
 
 <style is:global>
-  /* Zotero's pre-rendered Chicago-style bibliography wraps each entry in
-     a .csl-entry div. Style it to match the rest of the prose. */
   .bibliography-entry .csl-entry { margin: 0; }
   .bibliography-entry i,
   .bibliography-entry em { font-style: italic; }
-  /* Hanging indent that Chicago style traditionally uses. */
   .bibliography-entry {
     text-indent: -1.5rem;
     padding-left: 1.5rem;
-  }
-
-  /* Active filter chip — driven by the script below. */
-  .tag-chip[aria-pressed="true"] {
-    background-color: var(--color-accent);
-    color: var(--color-bg);
-    border-color: var(--color-accent);
-  }
-  .tag-chip[aria-pressed="true"] span:last-child {
-    color: var(--color-bg);
-    opacity: 0.8;
   }
 </style>
 
 <script>
   /*
-    Client-side tag filter. State lives in the URL hash so the filtered view
-    is shareable / bookmarkable, e.g. /bibliography#tags=cartography,zoning
+    Bibliography filter state lives in URL hash so views are shareable:
+        #q=climate                 — free-text search
+        #tags=Cartography,Networks — exact tag matches (AND-of-search,
+                                     OR-among-tags)
+        #q=climate&tags=Cartography
 
-    Filter logic is OR (an entry shows if it has ANY selected tag). Year
-    sections hide when none of their entries match.
+    Free-text filters by title + rendered citation (HTML stripped) + tag
+    names — substring match, case-insensitive. Tag filters require the
+    entry to carry every selected tag (AND), so adding more chips narrows
+    rather than widens.
 
-    Re-attaches on astro:page-load so it survives ClientRouter view transitions.
+    Re-attaches on astro:page-load to survive ClientRouter view transitions.
   */
 
-  type ParsedHash = { tags: Set<string> };
+  type State = { q: string; tags: Set<string> };
 
-  function parseHash(): ParsedHash {
-    const m = location.hash.match(/tags=([^&]+)/);
-    if (!m) return { tags: new Set() };
-    return {
-      tags: new Set(
-        decodeURIComponent(m[1])
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean),
-      ),
-    };
+  function parseHash(): State {
+    const out: State = { q: '', tags: new Set() };
+    const raw = location.hash.replace(/^#/, '');
+    if (!raw) return out;
+    for (const part of raw.split('&')) {
+      const [k, v = ''] = part.split('=');
+      const decoded = decodeURIComponent(v);
+      if (k === 'q') out.q = decoded;
+      else if (k === 'tags') {
+        decoded.split(',').map((s) => s.trim()).filter(Boolean).forEach((t) => out.tags.add(t));
+      }
+    }
+    return out;
   }
 
-  function writeHash(tags: Set<string>) {
-    if (tags.size === 0) {
-      // Strip the hash entirely instead of leaving '#'.
+  function writeHash(state: State) {
+    const parts: string[] = [];
+    if (state.q) parts.push(`q=${encodeURIComponent(state.q)}`);
+    if (state.tags.size > 0) parts.push(`tags=${encodeURIComponent([...state.tags].join(','))}`);
+    if (parts.length === 0) {
       history.replaceState(null, '', location.pathname + location.search);
     } else {
-      const v = encodeURIComponent([...tags].join(','));
-      history.replaceState(null, '', `${location.pathname}${location.search}#tags=${v}`);
+      history.replaceState(null, '', `${location.pathname}${location.search}#${parts.join('&')}`);
+    }
+  }
+
+  function renderActiveTagChips(tags: Set<string>) {
+    const container = document.querySelector<HTMLElement>('[data-bib-active-tags]');
+    if (!container) return;
+    container.innerHTML = '';
+    if (tags.size === 0) return;
+    for (const tag of tags) {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.dataset.tagRemove = tag;
+      chip.className =
+        'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-accent text-bg text-xs hover:bg-accent/85 transition-colors';
+      chip.innerHTML = `<span>${tag}</span><span aria-hidden="true">×</span>`;
+      chip.title = `Remove filter: ${tag}`;
+      container.appendChild(chip);
     }
   }
 
   function applyFilter() {
     const root = document.querySelector<HTMLElement>('[data-bibliography]');
-    const filter = document.querySelector<HTMLElement>('[data-tag-filter]');
-    const clearBtn = document.querySelector<HTMLButtonElement>('[data-tag-clear]');
+    const searchInput = document.querySelector<HTMLInputElement>('[data-bib-search]');
+    const clearBtn = document.querySelector<HTMLButtonElement>('[data-bib-clear]');
     const emptyMsg = document.querySelector<HTMLElement>('[data-empty-msg]');
-    if (!root || !filter) return;
+    if (!root) return;
 
-    const { tags } = parseHash();
+    const state = parseHash();
+    const q = state.q.toLowerCase().trim();
 
-    // Update chip pressed state.
-    filter.querySelectorAll<HTMLButtonElement>('.tag-chip').forEach((chip) => {
-      const tag = chip.dataset.tag ?? '';
-      chip.setAttribute('aria-pressed', String(tags.has(tag)));
-    });
+    if (searchInput && searchInput.value !== state.q) searchInput.value = state.q;
+    if (clearBtn) clearBtn.classList.toggle('hidden', !q && state.tags.size === 0);
+    renderActiveTagChips(state.tags);
 
-    if (clearBtn) clearBtn.classList.toggle('hidden', tags.size === 0);
-
-    // Filter entries (OR semantics).
     let matchedAny = false;
     root.querySelectorAll<HTMLElement>('[data-entry]').forEach((li) => {
       const entryTags = JSON.parse(li.dataset.entryTags || '[]') as string[];
-      const matches = tags.size === 0 || entryTags.some((t) => tags.has(t));
-      li.classList.toggle('hidden', !matches);
-      if (matches) matchedAny = true;
+      const text = li.dataset.entryText ?? '';
+
+      const matchesText = !q || text.includes(q);
+      const matchesTags =
+        state.tags.size === 0 || [...state.tags].every((t) => entryTags.includes(t));
+
+      const visible = matchesText && matchesTags;
+      li.classList.toggle('hidden', !visible);
+      if (visible) matchedAny = true;
     });
 
-    // Hide year sections that now have no visible entries.
-    root.querySelectorAll<HTMLElement>('[data-year-section]').forEach((section) => {
+    // Hide sections that have no visible entries; update the count display.
+    root.querySelectorAll<HTMLElement>('[data-section]').forEach((section) => {
       const visible = section.querySelectorAll<HTMLElement>('[data-entry]:not(.hidden)').length;
       section.classList.toggle('hidden', visible === 0);
+      const countEl = section.querySelector<HTMLElement>('[data-section-count]');
+      if (countEl) {
+        const total = section.querySelectorAll<HTMLElement>('[data-entry]').length;
+        countEl.textContent = visible === total ? `(${total})` : `(${visible} of ${total})`;
+      }
     });
 
-    if (emptyMsg) emptyMsg.classList.toggle('hidden', matchedAny || tags.size === 0);
+    if (emptyMsg) emptyMsg.classList.toggle('hidden', matchedAny || (!q && state.tags.size === 0));
   }
 
-  function attach() {
-    const filter = document.querySelector<HTMLElement>('[data-tag-filter]');
-    if (!filter) return;
+  let searchDebounce: number | undefined;
 
-    filter.querySelectorAll<HTMLButtonElement>('.tag-chip').forEach((chip) => {
-      chip.addEventListener('click', () => {
-        const { tags } = parseHash();
-        const tag = chip.dataset.tag ?? '';
-        if (tags.has(tag)) tags.delete(tag);
-        else tags.add(tag);
-        writeHash(tags);
+  function attach() {
+    const searchInput = document.querySelector<HTMLInputElement>('[data-bib-search]');
+    const clearBtn = document.querySelector<HTMLButtonElement>('[data-bib-clear]');
+    const activeTags = document.querySelector<HTMLElement>('[data-bib-active-tags]');
+
+    searchInput?.addEventListener('input', () => {
+      window.clearTimeout(searchDebounce);
+      searchDebounce = window.setTimeout(() => {
+        const state = parseHash();
+        state.q = searchInput.value;
+        writeHash(state);
         applyFilter();
+      }, 120);
+    });
+
+    clearBtn?.addEventListener('click', () => {
+      writeHash({ q: '', tags: new Set() });
+      applyFilter();
+    });
+
+    // Click any tag chip on an entry → add it to the active tag filter.
+    document.querySelectorAll<HTMLButtonElement>('[data-tag-add]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const tag = btn.dataset.tagAdd ?? '';
+        if (!tag) return;
+        const state = parseHash();
+        state.tags.add(tag);
+        writeHash(state);
+        applyFilter();
+        // Scroll to the top of the entry list so the user sees the result.
+        document.querySelector('[data-bibliography]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
       });
     });
 
-    filter.querySelector<HTMLButtonElement>('[data-tag-clear]')?.addEventListener('click', () => {
-      writeHash(new Set());
+    // Click a chip in the active filter row → remove that filter.
+    activeTags?.addEventListener('click', (e) => {
+      const target = (e.target as HTMLElement).closest<HTMLButtonElement>('[data-tag-remove]');
+      if (!target) return;
+      const tag = target.dataset.tagRemove ?? '';
+      const state = parseHash();
+      state.tags.delete(tag);
+      writeHash(state);
       applyFilter();
     });
 

--- a/src/pages/bibliography.astro
+++ b/src/pages/bibliography.astro
@@ -103,9 +103,35 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
         <div data-bib-active-tags class="flex flex-wrap gap-1.5 empty:hidden"></div>
       </div>
 
+      {renderedSections.length > 1 && (
+        <nav
+          aria-label="Jump to section"
+          class="mb-10 -mx-1 flex flex-wrap gap-1.5 text-sm"
+          data-section-jump
+        >
+          {renderedSections.map((section) => (
+            <a
+              href={`#section-${section.key}`}
+              data-jump-key={section.key}
+              class="inline-flex items-baseline gap-1.5 px-2.5 py-1 rounded-full border border-border text-text no-underline hover:border-accent hover:text-accent transition-colors"
+            >
+              <span>{section.name}</span>
+              <span class="text-xs text-subtle tabular-nums" data-jump-count>
+                {bySection[section.key].length}
+              </span>
+            </a>
+          ))}
+        </nav>
+      )}
+
       <div class="space-y-12" data-bibliography>
         {renderedSections.map((section) => (
-          <section data-section data-section-key={section.key}>
+          <section
+            id={`section-${section.key}`}
+            data-section
+            data-section-key={section.key}
+            class="scroll-mt-24"
+          >
             <h2 class="text-xs font-semibold text-accent uppercase tracking-[0.14em] mb-5">
               <span>{section.name}</span>
               <span class="ml-2 text-subtle font-normal" data-section-count>
@@ -278,13 +304,25 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
     });
 
     // Hide sections that have no visible entries; update the count display.
+    // Mirror the same hide/count change to the corresponding jump link so
+    // the top-of-page nav reflects what's actually visible below.
     root.querySelectorAll<HTMLElement>('[data-section]').forEach((section) => {
       const visible = section.querySelectorAll<HTMLElement>('[data-entry]:not(.hidden)').length;
+      const total = section.querySelectorAll<HTMLElement>('[data-entry]').length;
       section.classList.toggle('hidden', visible === 0);
       const countEl = section.querySelector<HTMLElement>('[data-section-count]');
       if (countEl) {
-        const total = section.querySelectorAll<HTMLElement>('[data-entry]').length;
         countEl.textContent = visible === total ? `(${total})` : `(${visible} of ${total})`;
+      }
+
+      const key = section.dataset.sectionKey;
+      if (key) {
+        const jump = document.querySelector<HTMLElement>(`[data-jump-key="${CSS.escape(key)}"]`);
+        if (jump) {
+          jump.classList.toggle('hidden', visible === 0);
+          const jumpCount = jump.querySelector<HTMLElement>('[data-jump-count]');
+          if (jumpCount) jumpCount.textContent = String(visible);
+        }
       }
     });
 

--- a/src/pages/bibliography.astro
+++ b/src/pages/bibliography.astro
@@ -109,14 +109,14 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
         >
           <nav
             aria-label="Jump to section"
-            class="max-w-full mx-auto px-4 sm:px-6 py-3 flex flex-wrap gap-1.5 text-sm"
+            class="section-jump-scroller max-w-full mx-auto px-4 sm:px-6 py-3 flex gap-1.5 text-sm overflow-x-auto"
             data-section-jump
           >
             {renderedSections.map((section) => (
               <a
                 href={`#section-${section.key}`}
                 data-jump-key={section.key}
-                class="inline-flex items-baseline gap-1.5 px-2.5 py-1 rounded-full border border-border text-text no-underline hover:border-accent hover:text-accent transition-colors"
+                class="jump-chip inline-flex items-baseline gap-1.5 px-2.5 py-1 rounded-full border border-border text-text no-underline hover:border-accent hover:text-accent transition-colors whitespace-nowrap shrink-0"
               >
                 <span>{section.name}</span>
                 <span class="text-xs text-subtle tabular-nums" data-jump-count>
@@ -155,21 +155,41 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
       </button>
 
       <div class="space-y-12" data-bibliography>
-        {renderedSections.map((section) => (
+        {renderedSections.map((section) => {
+          const isUncategorized = section.key === '__uncategorized__';
+          return (
           <section
             id={`section-${section.key}`}
             data-section
             data-section-key={section.key}
-            class="scroll-mt-24"
+            class="scroll-mt-40"
           >
-            <h2 class="text-xs font-semibold text-accent uppercase tracking-[0.14em] mb-5">
-              <span>{section.name}</span>
-              <span class="ml-2 text-subtle font-normal" data-section-count>
-                ({bySection[section.key].length})
-              </span>
-            </h2>
-            <ul class="space-y-5">
-              {bySection[section.key].map((entry) => (
+            <details open={!isUncategorized} data-section-details>
+              <summary class="cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+                <h2 class="text-xs font-semibold text-accent uppercase tracking-[0.14em] mb-5 inline-flex items-baseline gap-2 group">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="10"
+                    height="10"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="3"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="details-caret text-subtle group-hover:text-accent transition-transform"
+                    aria-hidden="true"
+                  >
+                    <polyline points="9 18 15 12 9 6" />
+                  </svg>
+                  <span>{section.name}</span>
+                  <span class="text-subtle font-normal" data-section-count>
+                    ({bySection[section.key].length})
+                  </span>
+                </h2>
+              </summary>
+              <ul class="space-y-5">
+                {bySection[section.key].map((entry) => (
                 <li
                   class="border-b border-border pb-5 last:border-b-0"
                   data-entry
@@ -223,9 +243,11 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
                   )}
                 </li>
               ))}
-            </ul>
+              </ul>
+            </details>
           </section>
-        ))}
+          );
+        })}
         <p data-empty-msg class="text-muted italic hidden">
           No entries match your filter.
         </p>
@@ -241,6 +263,37 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
   .bibliography-entry {
     text-indent: -1.5rem;
     padding-left: 1.5rem;
+  }
+
+  /* Hide the horizontal scrollbar on the sticky jump nav while keeping
+     overflow-x:auto scrolling. Edge fades give a "more here" affordance. */
+  .section-jump-scroller {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    mask-image: linear-gradient(
+      to right,
+      transparent,
+      black 1.5rem,
+      black calc(100% - 1.5rem),
+      transparent
+    );
+  }
+  .section-jump-scroller::-webkit-scrollbar { display: none; }
+
+  /* Active chip — the section currently in view. Set by the scrollspy. */
+  .jump-chip[aria-current="true"] {
+    background-color: var(--color-accent-soft);
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+  .jump-chip[aria-current="true"] span:last-child {
+    color: var(--color-accent);
+    opacity: 0.8;
+  }
+
+  /* Rotate the details caret 90° when the section is open. */
+  details[open] > summary .details-caret {
+    transform: rotate(90deg);
   }
 </style>
 
@@ -336,6 +389,9 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
     // Hide sections that have no visible entries; update the count display.
     // Mirror the same hide/count change to the corresponding jump link so
     // the top-of-page nav reflects what's actually visible below.
+    // Force-open Uncategorized's <details> when a filter is active and has
+    // matches there — so users see results rather than a collapsed shell.
+    const filterActive = !!q || state.tags.size > 0;
     root.querySelectorAll<HTMLElement>('[data-section]').forEach((section) => {
       const visible = section.querySelectorAll<HTMLElement>('[data-entry]:not(.hidden)').length;
       const total = section.querySelectorAll<HTMLElement>('[data-entry]').length;
@@ -352,6 +408,14 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
           jump.classList.toggle('hidden', visible === 0);
           const jumpCount = jump.querySelector<HTMLElement>('[data-jump-count]');
           if (jumpCount) jumpCount.textContent = String(visible);
+        }
+
+        // Open the section's <details> when a filter is active and this
+        // section has matches. Don't force it closed when the filter clears
+        // — let the user's manual open/close state stand.
+        if (filterActive && visible > 0) {
+          const details = section.querySelector<HTMLDetailsElement>('[data-section-details]');
+          if (details && !details.open) details.open = true;
         }
       }
     });
@@ -410,6 +474,55 @@ const allTagCount = new Set(entries.flatMap((e) => e.data.tags ?? [])).size;
 
     applyFilter();
     attachBackToTop();
+    attachScrollSpy();
+  }
+
+  function attachScrollSpy() {
+    const sections = document.querySelectorAll<HTMLElement>('[data-section]');
+    if (sections.length === 0) return;
+
+    // Map sectionKey → jump chip. Built once.
+    const chips = new Map<string, HTMLElement>();
+    document.querySelectorAll<HTMLElement>('[data-jump-key]').forEach((chip) => {
+      const key = chip.dataset.jumpKey ?? '';
+      if (key) chips.set(key, chip);
+    });
+
+    function clearActive() {
+      chips.forEach((chip) => chip.removeAttribute('aria-current'));
+    }
+
+    function markActive(key: string) {
+      clearActive();
+      const chip = chips.get(key);
+      if (!chip) return;
+      chip.setAttribute('aria-current', 'true');
+      // Bring the active chip into view in the horizontal scroller.
+      chip.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+    }
+
+    // Track visible sections; pick the topmost on each update. rootMargin
+    // accounts for the sticky header (~4rem) + sticky jump nav (~3rem) so
+    // a section becomes "active" right when its heading slides under the
+    // sticky bars.
+    const visible = new Set<HTMLElement>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) visible.add(entry.target as HTMLElement);
+          else visible.delete(entry.target as HTMLElement);
+        }
+        if (visible.size === 0) return;
+        // Topmost-in-viewport wins.
+        const topmost = [...visible].sort(
+          (a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top,
+        )[0];
+        const key = topmost.dataset.sectionKey;
+        if (key) markActive(key);
+      },
+      { rootMargin: '-7rem 0px -60% 0px', threshold: 0 },
+    );
+    sections.forEach((s) => observer.observe(s));
   }
 
   function attachBackToTop() {


### PR DESCRIPTION
## Summary

Replaces the chip-cloud tag filter (didn't scale past ~10 tags) and the year-based grouping with a Zotero sub-collection structure plus a free-text search. Designed to handle 100+ entries and 100+ unique tags without the page becoming a wall of chips.

## Behavior

**Sections** — entries are grouped under their Zotero sub-collection (top-level on the page). With your current 7 sub-collections, that's `AI`, `cartography + visualization`, `case studies`, `infrastructure`, `methods`, `networks`, `theory`. Items in no sub-collection appear under "Uncategorized" at the bottom. If you ever delete the sub-collections, the page falls back to a single "All references" section.

**Search** — single text input at the top. Matches title + rendered citation + tag name as a substring. Debounced 120ms. Clears via the visible "Clear" button.

**Tag filters** — every tag chip on an entry is now clickable. Click it → adds to active tag filters (AND semantics — more chips means narrower results). Active filters show as removable chips above the entries.

**Shareable state** — both search and selected tags persist in the URL hash:
- `/bibliography#q=climate`
- `/bibliography#tags=Cartography,Networks`
- `/bibliography#q=climate&tags=Networks`

Sections collapse when none of their entries match. Headings show "(N visible of M)" when filtered, "(N)" otherwise.

## To test once you've moved items into sub-collections

```bash
git checkout feat/bibliography-subcollections
git pull
set -a; source .env; set +a; npm run build:resources
git add src/data/zotero.json
git commit -m "refresh: zotero with sub-collection assignments"
git push
npm run dev   # http://localhost:4321/bibliography
```

The PR currently shows everything under "Uncategorized" because no items are assigned to sub-collections yet — moving them in Zotero + re-running the fetch is the only thing that flips the structure on.

## Files changed

- `scripts/fetch-zotero.ts` — added sub-collection fetch + per-item collections capture
- `src/content.config.ts` — `subcollections: string[]` added to the bibliography schema
- `src/data/zotero.json` — refetched with the new fields (still 163 entries)
- `src/pages/bibliography.astro` — rewritten: section grouping, search input, click-tag-to-filter, hash state

## Future work flagged

- Per-section tag counts in active filter chips (e.g. "Cartography (3)" showing matches in current view)
- "Show only N most-recent" toggle if a section gets very long
- Inline citation shortcodes in lessons (still on the original wishlist)
